### PR TITLE
feat(api): add swagger for doc generation

### DIFF
--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -139,7 +139,9 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'corsheaders',
     # Deis apps
-    'api'
+    'api',
+    # Docs
+    'rest_framework_swagger',
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -12,4 +12,5 @@ from api.views import HealthCheckView
 urlpatterns = [
     url(r'^health-check$', HealthCheckView.as_view()),
     url(r'^v2/', include('api.urls')),
+    url(r'^docs/?', include('rest_framework_swagger.urls')),
 ]

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -15,3 +15,4 @@ requests==2.9.1
 git+https://github.com/helgi/python-simpleflock.git@python3#egg=simpleflock
 static==1.1.1
 morph==0.1.2
+django-rest-swagger==0.3.4


### PR DESCRIPTION
Gives a pretty interactive API doc endpoint using swagger, http://swagger.io/.

http://www.django-rest-framework.org/topics/documenting-your-api/ lists all the available options, including the built in DRF one

Note, right now it is not disabled or for authenticated users only. That is configurable if we want to go there.