### PR TITLE
fix(travis): update secure URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
 notifications:
   webhooks:
     urls:
-      - secure: "Kirwb8QgjbctztB/ze89XmrukN/1tS8Vb3ZVrAidusVJdHakiEJbbSDTnMuDcLwY+MXZfMM1zRDpXOnbG4QKOUjh1ytPCY9cKsbSuQ3oH+siCJk2oFtIDcs35hp5iNSq+B4YjttexSKOR2opNXkGuTHoVPVb6t10JIXPLuL3YCphlvCTWzLb5aV/yHHaIalkZV//5E+gmvOzUEYrS1/d+Hrp0yFoD9zH1ze+kIRTx6RiXTwG/Y6Z3e5PH2Jpygv37rNCiedE4CtQGR3sjashzciU7f5WZpMaTdhUdOY3vHFzq0Zz6iZb1jbzFdnUsPjHsG6e8zqh7p4XVrct1RGecd40tTcYXbohSX0izujvqSzFMqb/Chh5jrad6quo8tlTLTcldSIdCP3lSJolod4x9SWewGQAXJ0+w7yiBTyA+vTLHQEYD8xrWbkwk8KLjfwLGuDwW9ijvhci5hV9w/cEO0L0pjCaLUftmbol6ZIcuX2lxBAm8QnNoYgH5B8uI6pxzIZ9i1wGtszPBB/9qCKtTV8hy2L0rrCeOUqyigcbASuoJ1naah7nn2xeD5zvaTe9jhVJrIxpbiWxfjGxzhz7h4UL8OsnQAXL/yFcesixLIKqwkSRNP0GAHBTQFb8yzTicFThqsnb8hsXardTCZJ2M2ohf6bGhx0ujE/Cjg+X0lk="
+      - secure: "FnxmxLYI0JNavYOma3ZZamaY8cTCjaMDPz5RoWu1NG9l3k3xTkkXpHT5qcnQHycyCtVb8rNIoVMzdtyrs3BlVTaWdrzP/J2sJoc8/1NvuOZCTS0D1EbjS7DGV3xENDdSdTylOUWeFzti8dD3ORZ/bbdCHkMiVi3MIxlAQANWq8k="
     on_success: always
     on_failure: never
     on_start: never


### PR DESCRIPTION
The job name at https://ci.deis.io has been changed to
controller-master, so travis needs to be updated to push to that
job.