### PR TITLE
feat(Makefile): add test-unit-quick target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ $(shell kubectl get rc deis-$(COMPONENT) --namespace deis -o yaml > /tmp/deis-$(
 DESIRED_REPLICAS=$(shell kubectl get -o template rc/deis-$(COMPONENT) --template={{.status.replicas}} --namespace deis)
 endif
 
+# Test processes used in quick unit testing
+TEST_PROCS ?= 4
+
 check-docker:
 	@if [ -z $$(which docker) ]; then \
 	  echo "Missing \`docker\` client which is required for development"; \
@@ -66,6 +69,10 @@ test-unit:
 	cd rootfs \
 		&& coverage run manage.py test --noinput registry api \
 		&& coverage report -m
+
+test-unit-quick:
+	cd rootfs \
+		&& ./manage.py test --noinput --parallel ${TEST_PROCS} --noinput registry api
 
 test-functional:
 	@echo "Implement functional tests in _tests directory"


### PR DESCRIPTION
The `--parallel` flag speeds up the overall unit test suite, but at the cost of CPU usage and code coverage reports.

```console
$ TEST_PROCS=6 make test-unit-quick
cd rootfs \
		&& ./manage.py test --noinput --parallel 6 --noinput registry api
Creating test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
.................................................................................................................................................................
----------------------------------------------------------------------
Ran 161 tests in 17.318s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
```