### PR TITLE
fix(dev_requirements): add tblib for multiprocessing tracebacks

### DIFF
--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -9,3 +9,6 @@ codecov==1.6.3
 
 # mock out python-requests, mostly k8s
 requests-mock==0.7.0
+
+# tblib is needed to pickle tracebacks for `make test-unit-quick`
+tblib==1.3.0


### PR DESCRIPTION
After running unit tests many times, I eventually hit an error and found the `make test-unit-quick` version needs a support library in order to pickle (serialize) python traceback objects:
```console
$ make test-unit-quick
cd rootfs \
		&& ./manage.py test --noinput --parallel 4 --noinput registry api
Creating test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...


test_certficate_denied_requests (api.tests.test_certificate.CertificateTest) failed:

    FileNotFoundError(2, 'No such file or directory')

Unfortunately, tracebacks cannot be pickled, making it impossible for the
parallel test runner to handle this exception cleanly.

In order to see the traceback, you should install tblib:

    pip install tblib

multiprocessing.pool.RemoteTraceback:
```
This Makefile target isn't used in CI, but adding it to dev_requirements.txt should help other devs who use the quick version of the unit tests. See #524.