### PR TITLE
chore(tests): remove various redundant python-request mocks

### DIFF
--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.test.runner import DiscoverRunner
-import requests
 
 
 class SilentDjangoTestSuiteRunner(DiscoverRunner):
@@ -13,14 +12,3 @@ class SilentDjangoTestSuiteRunner(DiscoverRunner):
         logging.disable(logging.ERROR)
         return super(SilentDjangoTestSuiteRunner, self).run_tests(
             test_labels, extra_tests, **kwargs)
-
-
-def mock_status_ok(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
-
-
-def mock_none(*args, **kwargs):
-    return None

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -16,7 +16,10 @@ from django.test import TestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import App
-from . import mock_status_ok, mock_none
+
+
+def mock_none(*args, **kwargs):
+    return None
 
 
 class AppTest(TestCase):
@@ -200,7 +203,6 @@ class AppTest(TestCase):
         self.assertIn('structure', response.data)
         self.assertEqual(response.data['structure'], {"web": 1})
 
-    @mock.patch('requests.post', mock_status_ok)
     @mock.patch('api.models.logger')
     def test_admin_can_manage_other_apps(self, mock_logger):
         """Administrators of Deis should be able to manage all applications.

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -14,7 +14,6 @@ from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Build
-from . import mock_status_ok
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
@@ -32,7 +31,6 @@ class BuildTest(TransactionTestCase):
         # make sure every test has a clean slate for k8s mocking
         cache.clear()
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_build(self):
         """
         Test that a null build is created and that users can post new builds
@@ -80,7 +78,6 @@ class BuildTest(TransactionTestCase):
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 405)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
@@ -107,7 +104,6 @@ class BuildTest(TransactionTestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_build_default_containers(self):
         url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -208,7 +204,6 @@ class BuildTest(TransactionTestCase):
         # pod name is auto generated so use regex
         self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_build_str(self):
         """Test the text representation of a build."""
         url = '/v2/apps'
@@ -225,7 +220,6 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(str(build), "{}-{}".format(
                          response.data['app'], str(response.data['uuid'])[:7]))
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_admin_can_create_builds_on_other_apps(self):
         """If a user creates an application, an administrator should be able
         to push builds.
@@ -249,7 +243,6 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(str(build), "{}-{}".format(
                          response.data['app'], str(response.data['uuid'])[:7]))
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_unauthorized_user_cannot_modify_build(self):
         """
         An unauthorized user should not be able to modify other builds.
@@ -270,7 +263,6 @@ class BuildTest(TransactionTestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
         self.assertEqual(response.status_code, 403)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_new_build_does_not_scale_up_automatically(self):
         """
         After the first initial deploy, if the containers are scaled down to zero,

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -14,8 +14,6 @@ from django.test import TransactionTestCase
 from unittest import mock
 from rest_framework.authtoken.models import Token
 
-from . import mock_status_ok
-
 RSA_PUBKEY = (
     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfQkkUUoxpvcNMkvv7jqnfodgs37M2eBO"
     "APgLK+KNBMaZaaKB4GF1QhTCMfFhoiTW3rqa0J75bHJcdkoobtTHlK8XUrFqsquWyg3XhsT"
@@ -196,7 +194,6 @@ class HookTest(TransactionTestCase):
                                     HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
         self.assertEqual(response.status_code, 403)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_build_hook(self):
         """Test creating a Build via an API Hook"""
         url = '/v2/apps'
@@ -218,7 +215,6 @@ class HookTest(TransactionTestCase):
         self.assertIn('release', response.data)
         self.assertIn('version', response.data['release'])
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_build_hook_slug_url(self):
         """Test creating a slug_url build via an API Hook"""
         url = '/v2/apps'

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -14,7 +14,6 @@ from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Build, Release
-from . import mock_status_ok
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
@@ -132,7 +131,6 @@ class PodTest(TransactionTestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_container_api_docker(self):
         url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -209,7 +207,6 @@ class PodTest(TransactionTestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_release(self):
         url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -15,7 +15,6 @@ from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Release
-from . import mock_status_ok
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
@@ -33,7 +32,6 @@ class ReleaseTest(TransactionTestCase):
         # make sure every test has a clean slate for k8s mocking
         cache.clear()
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_release(self):
         """
         Test that a release is created when an app is created, and
@@ -110,7 +108,6 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(response.status_code, 405)
         return release3
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_response_data(self):
         body = {'id': 'test'}
         response = self.client.post('/v2/apps', json.dumps(body),
@@ -135,7 +132,6 @@ class ReleaseTest(TransactionTestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_release_rollback(self):
         url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -233,14 +229,12 @@ class ReleaseTest(TransactionTestCase):
         self.assertIn('NEW_URL1', values)
         self.assertEqual('http://localhost:8080/', values['NEW_URL1'])
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_release_str(self):
         """Test the text representation of a release."""
         release3 = self.test_release()
         release = Release.objects.get(uuid=release3['uuid'])
         self.assertEqual(str(release), "{}-v3".format(release3['app']))
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_release_summary(self):
         """Test the text summary of a release."""
         release3 = self.test_release()
@@ -248,7 +242,6 @@ class ReleaseTest(TransactionTestCase):
         # check that the release has push and env change messages
         self.assertIn('autotest deployed ', release.summary)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_admin_can_create_release(self):
         """If a non-user creates an app, an admin should be able to create releases."""
         user = User.objects.get(username='autotest2')
@@ -272,7 +265,6 @@ class ReleaseTest(TransactionTestCase):
         # account for the config release as well
         self.assertEqual(response.data['count'], 2)
 
-    @mock.patch('requests.post', mock_status_ok)
     def test_unauthorized_user_cannot_modify_release(self):
         """
         An unauthorized user should not be able to modify other releases.


### PR DESCRIPTION
They are not needed now that scheduler uses a request mock in the background