### PR TITLE
feat(apps): validate routeability through deis-router upon application creation

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -3,15 +3,19 @@ import logging
 import random
 import re
 import requests
+from requests_toolbelt import user_agent
 import string
 import time
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.db import models
 from django.core.exceptions import ValidationError
 from jsonfield import JSONField
 
+from deis import __version__ as deis_version
 from api.models import UuidAuditedModel, log_event, AlreadyExists
+
 from api.utils import generate_app_name, app_build_type
 from api.models.release import Release
 from api.models.config import Config
@@ -304,7 +308,9 @@ class App(UuidAuditedModel):
                 'replicas': scale_types[scale_type],
                 'app_type': scale_type,
                 'build_type': build_type,
-                'healthcheck': release.config.healthcheck()
+                'healthcheck': release.config.healthcheck(),
+                # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
+                'routable': True if scale_type in ['web', 'cmd'] else False
             }
 
             command = self._get_command(scale_type)
@@ -348,7 +354,9 @@ class App(UuidAuditedModel):
                 'version': version,
                 'app_type': scale_type,
                 'build_type': build_type,
-                'healthcheck': release.config.healthcheck()
+                'healthcheck': release.config.healthcheck(),
+                # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
+                'routable': True if scale_type in ['web', 'cmd'] else False
             }
 
             command = self._get_command(scale_type)
@@ -360,6 +368,13 @@ class App(UuidAuditedModel):
                     command=command,
                     **kwargs
                 )
+
+                # Wait until application is available in the router
+                # Only run when there is no previous build / release
+                old = release.previous()
+                if old is None or old.build is None:
+                    self.verify_application_health(**kwargs)
+
             except Exception as e:
                 err = '{} (app::deploy): {}'.format(self._get_job_id(scale_type), e)
                 log_event(self, err, logging.ERROR)
@@ -384,6 +399,79 @@ class App(UuidAuditedModel):
             structure = {'web': 1}
 
         return structure
+
+    def verify_application_health(self, **kwargs):
+        """
+        Verify an application is healthy via the router.
+        This is only used in conjunction with the kubernetes health check system and should
+        only run after kubernetes has reported all pods as healthy
+        """
+        # Bail out early if the application is not routable
+        if not kwargs.get('routable', False):
+            return
+
+        app_type = kwargs.get('app_type')
+        self.log(
+            'Waiting for router to be ready to serve traffic to process type {}'.format(app_type),
+            level=logging.DEBUG
+        )
+
+        # Get the router host and append healthcheck path
+        url = 'http://{}:{}'.format(settings.ROUTER_HOST, settings.ROUTER_PORT)
+
+        # if a health check url is available then 200 is the only acceptable status code
+        if len(kwargs['healthcheck']):
+            allowed = [200]
+            url = urljoin(url, kwargs['healthcheck'].get('path'))
+            req_timeout = kwargs['healthcheck'].get('timeout')
+        else:
+            allowed = set(range(200, 599))
+            allowed.remove(404)
+            req_timeout = 3
+
+        session = requests.Session()
+        session.headers = {
+            # https://toolbelt.readthedocs.org/en/latest/user-agent.html#user-agent-constructor
+            'User-Agent': user_agent('Deis Controller', deis_version),
+            # set the Host header for the application being checked - not used for actual routing
+            'Host': '{}.{}.nip.io'.format(self.id, settings.ROUTER_HOST)
+        }
+
+        # `mount` a custom adapter that retries failed connections for HTTP and HTTPS requests.
+        # http://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
+        session.mount('http://', requests.adapters.HTTPAdapter(max_retries=10))
+        session.mount('https://', requests.adapters.HTTPAdapter(max_retries=10))
+
+        # Give the router max of 10 tries or max 30 seconds to become healthy
+        # Uses time module to account for the timout value of 3 seconds
+        start = time.time()
+        for _ in range(10):
+            # http://docs.python-requests.org/en/master/user/advanced/#timeouts
+            response = session.get(url, timeout=req_timeout)
+
+            # 1 minute timeout
+            if (time.time() - start) > (req_timeout * 10):
+                break
+
+            # check response against the allowed pool
+            if response.status_code in allowed:
+                break
+
+            # a small sleep since router usually resolve within 10 seconds
+            time.sleep(1)
+
+        # Endpoint did not report healthy in time
+        if response.status_code == 404:
+            self.log(
+                'Router was not ready to serve traffic to process type {} in time'.format(app_type),  # noqa
+                level=logging.WARNING
+            )
+            return
+
+        self.log(
+            'Router is ready to serve traffic to process type {}'.format(app_type),
+            level=logging.DEBUG
+        )
 
     def logs(self, log_lines=str(settings.LOG_LINES)):
         """Return aggregated log data for this application."""

--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -1,6 +1,39 @@
 import logging
+import random
+import requests_mock
+import time
 
+from django.conf import settings
 from django.test.runner import DiscoverRunner
+
+
+# Mock out router requests and add in some jitter
+# Used for application is available in router checks
+def fake_responses(request, context):
+    responses = [
+        # increasing the chance of 404
+        {'text': 'Not Found', 'status_code': 404},
+        {'text': 'Not Found', 'status_code': 404},
+        {'text': 'Not Found', 'status_code': 404},
+        {'text': 'Not Found', 'status_code': 404},
+        {'text': 'OK', 'status_code': 200},
+        {'text': 'Gateway timeout', 'status_code': 504},
+        {'text': 'Bad gateway', 'status_code': 502},
+    ]
+    random.shuffle(responses)
+    response = responses.pop()
+
+    context.status_code = response['status_code']
+    context.reason = response['text']
+    # Random float x, 1.0 <= x < 4.0 for some sleep jitter
+    time.sleep(random.uniform(1, 4))
+    return response['text']
+
+url = 'http://{}:{}'.format(settings.ROUTER_HOST, settings.ROUTER_PORT)
+adapter = requests_mock.Adapter()
+adapter.register_uri('GET', url + '/', text=fake_responses)
+adapter.register_uri('GET', url + '/health', text=fake_responses)
+adapter.register_uri('GET', url + '/healthz', text=fake_responses)
 
 
 class SilentDjangoTestSuiteRunner(DiscoverRunner):

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -275,6 +275,10 @@ REGISTRY_URL = '{}:{}'.format(REGISTRY_HOST, REGISTRY_PORT)
 LOGGER_HOST = os.environ.get('DEIS_LOGGER_SERVICE_HOST', '127.0.0.1')
 LOGGER_PORT = os.environ.get('DEIS_LOGGER_SERVICE_PORT_HTTP', 80)
 
+# router information
+ROUTER_HOST = os.environ.get('DEIS_ROUTER_SERVICE_HOST', '127.0.0.1')
+ROUTER_PORT = os.environ.get('DEIS_ROUTER_SERVICE_PORT', 80)
+
 # check if we can register users with `deis register`
 REGISTRATION_MODE = os.environ.get('REGISTRATION_MODE', 'enabled')
 

--- a/rootfs/deis/testing.py
+++ b/rootfs/deis/testing.py
@@ -6,6 +6,10 @@ from deis.settings import *  # noqa
 SCHEDULER_MODULE = 'scheduler.mock'
 SCHEDULER_URL = 'http://test-scheduler.example.com'
 
+# router information
+ROUTER_HOST = 'deis-router.example.com'
+ROUTER_PORT = 80
+
 # randomize test database name so we can run multiple unit tests simultaneously
 DATABASES['default']['NAME'] = "unittest-{}".format(''.join(
     random.choice(string.ascii_letters + string.digits) for _ in range(8)))

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -8,7 +8,8 @@ flake8==2.5.4
 codecov==1.6.3
 
 # mock out python-requests, mostly k8s
-requests-mock==0.7.0
+# requests-mock==0.7.0
+-e git+https://github.com/helgi/requests-mock.git@class_adapter#egg=request_mock
 
 # tblib is needed to pickle tracebacks for `make test-unit-quick`
 tblib==1.3.0

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -395,12 +395,12 @@ class MockSchedulerClient(KubeHTTPClient):
         self.url = settings.SCHEDULER_URL
         self.registry = settings.REGISTRY_URL
 
-        self.adapter = requests_mock.Adapter()
+        adapter = requests_mock.Adapter()
         self.session = requests.Session()
-        self.session.mount(self.url, self.adapter)
+        self.session.mount(self.url, adapter)
 
         # Lets just listen to everything and sort it out ourselves
-        self.adapter.register_uri(
+        adapter.register_uri(
             requests_mock.ANY, requests_mock.ANY,
             json=mock
         )


### PR DESCRIPTION
Hits the router IP via python-requests with a Host header (uses nip.io) to emulate a request to the application. Sends a Deis Controller UA to make debugging easier
HTTP mocking is required for this to work in tests and all tests now get peppered with mock_requests object, which they can use for other purposes as well if required

Depends on a change to the requests_mock python package for testing only, pulling that from git currently

Tests take 2x the time because of added timing jitter to emulate router being slow to respond at times

Fixes #551