### PR TITLE
fix(Makefile): fix commit-msg task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean: check-docker
 	docker rmi $(IMAGE)
 
 commit-hook:
-	cp contrib/util/commit-msg .git/hooks/commit-msg
+	cp _scripts/util/commit-msg .git/hooks/commit-msg
 
 full-clean: check-docker
 	docker images -q $(IMAGE_PREFIX)$(COMPONENT) | xargs docker rmi -f


### PR DESCRIPTION
When contrib scripts were moved to _scripts this didn't get updated.

Now that we have many deis repositories however, it may more sense to remove this from here and instead move it to the documentation.