### PR TITLE
ref(tests): move to using the TestCase classes DRF provides

### DIFF
--- a/rootfs/api/tests/test_api_middleware.py
+++ b/rootfs/api/tests/test_api_middleware.py
@@ -5,13 +5,13 @@ Run the tests with "./manage.py test api"
 """
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 from api import __version__
 
 
-class APIMiddlewareTest(TestCase):
+class APIMiddlewareTest(APITestCase):
 
     """Tests middleware.py's business logic"""
 
@@ -20,6 +20,7 @@ class APIMiddlewareTest(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
     def test_deis_version_header_good(self):
         """
@@ -27,8 +28,7 @@ class APIMiddlewareTest(TestCase):
         """
         response = self.client.get(
             '/v2/apps',
-            HTTP_DEIS_VERSION=__version__.rsplit('.', 2)[0],
-            HTTP_AUTHORIZATION='token {}'.format(self.token),
+            HTTP_DEIS_VERSION=__version__.rsplit('.', 2)[0]
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.has_header('DEIS_API_VERSION'), True)
@@ -40,8 +40,7 @@ class APIMiddlewareTest(TestCase):
         """
         response = self.client.get(
             '/v2/apps',
-            HTTP_DEIS_VERSION='1234.5678',
-            HTTP_AUTHORIZATION='token {}'.format(self.token),
+            HTTP_DEIS_VERSION='1234.5678'
         )
         self.assertEqual(response.status_code, 405)
 
@@ -49,6 +48,5 @@ class APIMiddlewareTest(TestCase):
         """
         Test that when the version header is not present, the request is accepted.
         """
-        response = self.client.get('/v2/apps',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -3,18 +3,13 @@ Unit tests for the Deis api app.
 
 Run the tests with "./manage.py test api"
 """
-
-
-import json
-from urllib.parse import urlencode
-
 from django.contrib.auth.models import User
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from django.test.utils import override_settings
 from rest_framework.authtoken.models import Token
 
 
-class AuthTest(TestCase):
+class AuthTest(APITestCase):
 
     fixtures = ['test_auth.json']
 
@@ -47,7 +42,7 @@ class AuthTest(TestCase):
             'is_staff': True,
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         for key in response.data:
             self.assertIn(key, ['id', 'last_login', 'is_superuser', 'username', 'first_name',
@@ -63,12 +58,10 @@ class AuthTest(TestCase):
             'is_staff': False
         }
         self.assertDictContainsSubset(expected, response.data)
+
         # test login
-        url = '/v2/auth/login/'
-        payload = urlencode({'username': username, 'password': password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.login(username=username, password=password)
+        self.assertEqual(response, True)
 
     @override_settings(REGISTRATION_MODE="disabled")
     def test_auth_registration_disabled(self):
@@ -83,7 +76,7 @@ class AuthTest(TestCase):
             'is_superuser': False,
             'is_staff': False,
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 403)
 
     @override_settings(REGISTRATION_MODE="admin_only")
@@ -99,7 +92,7 @@ class AuthTest(TestCase):
             'is_superuser': False,
             'is_staff': False,
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 403)
 
     @override_settings(REGISTRATION_MODE="admin_only")
@@ -121,7 +114,7 @@ class AuthTest(TestCase):
             'is_superuser': True,
             'is_staff': True,
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
 
         self.assertEqual(response.status_code, 201)
@@ -139,12 +132,10 @@ class AuthTest(TestCase):
             'is_staff': False
         }
         self.assertDictContainsSubset(expected, response.data)
+
         # test login
-        url = '/v2/auth/login/'
-        payload = urlencode({'username': username, 'password': password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.login(username=username, password=password)
+        self.assertEqual(response, True)
 
     @override_settings(REGISTRATION_MODE="not_a_mode")
     def test_auth_registration_fails_with_nonexistant_mode(self):
@@ -161,7 +152,7 @@ class AuthTest(TestCase):
         }
 
         try:
-            self.client.post(url, json.dumps(submit), content_type='application/json')
+            self.client.post(url, submit)
         except Exception as e:
             self.assertEqual(str(e), 'not_a_mode is not a valid registation mode')
 
@@ -191,33 +182,30 @@ class AuthTest(TestCase):
             'is_staff': False,
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
 
         # cancel the account
         url = '/v2/auth/cancel'
         user = User.objects.get(username=username)
         token = Token.objects.get(user=user).key
-        response = self.client.delete(url,
-                                      HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 204)
 
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(other_submit), content_type='application/json')
+        response = self.client.post(url, other_submit)
         self.assertEqual(response.status_code, 201)
 
         # normal user can't delete another user
         url = '/v2/auth/cancel'
         other_user = User.objects.get(username=other_username)
         other_token = Token.objects.get(user=other_user).key
-        response = self.client.delete(url, json.dumps({'username': self.admin.username}),
-                                      content_type='application/json',
+        response = self.client.delete(url, {'username': self.admin.username},
                                       HTTP_AUTHORIZATION='token {}'.format(other_token))
         self.assertEqual(response.status_code, 403)
 
         # admin can delete another user
-        response = self.client.delete(url, json.dumps({'username': other_username}),
-                                      content_type='application/json',
+        response = self.client.delete(url, {'username': other_username},
                                       HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
         self.assertEqual(response.status_code, 204)
 
@@ -230,8 +218,7 @@ class AuthTest(TestCase):
         app_id = response.data['id']  # noqa
         self.assertIn('id', response.data)
 
-        response = self.client.delete(url, json.dumps({'username': str(self.admin)}),
-                                      content_type='application/json',
+        response = self.client.delete(url, {'username': str(self.admin)},
                                       HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
         self.assertEqual(response.status_code, 409)
 
@@ -249,7 +236,7 @@ class AuthTest(TestCase):
             'email': email,
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         # change password
         url = '/v2/auth/passwd'
@@ -259,7 +246,7 @@ class AuthTest(TestCase):
             'password': 'password2',
             'new_password': password,
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {'detail': 'Current password does not match'})
@@ -268,20 +255,17 @@ class AuthTest(TestCase):
             'password': password,
             'new_password': 'password2',
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 200)
+
         # test login with old password
-        url = '/v2/auth/login/'
-        payload = urlencode({'username': username, 'password': password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 400)
+        response = self.client.login(username=username, password=password)
+        self.assertEqual(response, False)
+
         # test login with new password
-        payload = urlencode({'username': username, 'password': 'password2'})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.login(username=username, password='password2')
+        self.assertEqual(response, True)
 
     def test_change_user_passwd(self):
         """
@@ -295,63 +279,52 @@ class AuthTest(TestCase):
             'username': self.user1.username,
             'new_password': new_password,
         }
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
         self.assertEqual(response.status_code, 200)
+
         # test login with old password
-        url = '/v2/auth/login/'
-        payload = urlencode({'username': self.user1.username, 'password': old_password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 400)
+        response = self.client.login(username=self.user1.username, password=old_password)
+        self.assertEqual(response, False)
+
         # test login with new password
-        payload = urlencode({'username': self.user1.username, 'password': new_password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.login(username=self.user1.username, password=new_password)
+        self.assertEqual(response, True)
+
         # Non-admins can't change another user's password
         submit['password'], submit['new_password'] = submit['new_password'], old_password
         url = '/v2/auth/passwd'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.user2_token))
         self.assertEqual(response.status_code, 403)
+
         # change back password with a regular user
-        response = self.client.post(url, json.dumps(submit), content_type='application/json',
+        response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.user1_token))
         self.assertEqual(response.status_code, 200)
+
         # test login with new password
-        url = '/v2/auth/login/'
-        payload = urlencode({'username': self.user1.username, 'password': old_password})
-        response = self.client.post(url, data=payload,
-                                    content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        response = self.client.login(username=self.user1.username, password=old_password)
+        self.assertEqual(response, True)
 
     def test_regenerate(self):
         """ Test that token regeneration works"""
-
         url = '/v2/auth/tokens/'
 
-        response = self.client.post(url, '{}', content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
-
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token)
+        response = self.client.post(url, {})
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.data['token'], self.admin_token)
 
-        self.admin_token = Token.objects.get(user=self.admin)
+        self.admin_token = Token.objects.get(user=self.admin).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token)
 
-        response = self.client.post(url, '{"username" : "autotest2"}',
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
-
+        response = self.client.post(url, {"username": "autotest2"})
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.data['token'], self.user1_token)
 
-        response = self.client.post(url, '{"all" : "true"}',
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+        response = self.client.post(url, {"all": "true"})
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.post(url, '{}', content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
-
+        response = self.client.post(url, {})
         self.assertEqual(response.status_code, 401)

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -9,7 +9,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TransactionTestCase
+from rest_framework.test import APITransactionTestCase
 from unittest import mock
 from rest_framework.authtoken.models import Token
 
@@ -17,7 +17,7 @@ from api.models import Build
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-class BuildTest(TransactionTestCase):
+class BuildTest(APITransactionTestCase):
 
     """Tests build notification from build system"""
 
@@ -26,6 +26,7 @@ class BuildTest(TransactionTestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
     def tearDown(self):
         # make sure every test has a clean slate for k8s mocking
@@ -36,60 +37,53 @@ class BuildTest(TransactionTestCase):
         Test that a null build is created and that users can post new builds
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # check to see that no initial build was created
         url = "/v2/apps/{app_id}/builds".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 0)
         # post a new build
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         build_id = str(response.data['uuid'])
         build1 = response.data
         self.assertEqual(response.data['image'], body['image'])
         # read the build
         url = "/v2/apps/{app_id}/builds/{build_id}".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         build2 = response.data
         self.assertEqual(build1, build2)
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('deis-release', response._headers)
         build3 = response.data
         self.assertEqual(response.data['image'], body['image'])
         self.assertNotEqual(build2['uuid'], build3['uuid'])
         # disallow put/patch/delete
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
 
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
         url = '/v2/apps'
-        response = self.client.post(url, json.dumps(body),
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         # post an image as a build
         url = "/v2/apps/test/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
 
         for key in response.data:
             self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'dockerfile',
@@ -106,18 +100,17 @@ class BuildTest(TransactionTestCase):
 
     def test_build_default_containers(self):
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post an image as a build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
@@ -128,7 +121,7 @@ class BuildTest(TransactionTestCase):
 
         # start with a new app
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build with procfile
@@ -136,13 +129,11 @@ class BuildTest(TransactionTestCase):
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'dockerfile': "FROM scratch"}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
@@ -153,7 +144,7 @@ class BuildTest(TransactionTestCase):
 
         # start with a new app
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
 
@@ -163,13 +154,11 @@ class BuildTest(TransactionTestCase):
                 'sha': 'a'*40,
                 'dockerfile': "FROM scratch",
                 'procfile': {'worker': 'node worker.js'}}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
@@ -180,7 +169,7 @@ class BuildTest(TransactionTestCase):
 
         # start with a new app
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build with procfile
@@ -190,12 +179,11 @@ class BuildTest(TransactionTestCase):
                 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js',
                                         'worker': 'node worker.js'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
@@ -207,14 +195,13 @@ class BuildTest(TransactionTestCase):
     def test_build_str(self):
         """Test the text representation of a build."""
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         build = Build.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(build), "{}-{}".format(
@@ -227,16 +214,18 @@ class BuildTest(TransactionTestCase):
         # create app as non-admin
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
 
         # post a new build as admin
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
         build = Build.objects.get(uuid=response.data['uuid'])
@@ -253,14 +242,14 @@ class BuildTest(TransactionTestCase):
         app_id = 'autotest'
         url = '/v2/apps'
         body = {'id': app_id}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
+
         unauthorized_user = User.objects.get(username='autotest2')
         unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
         url = '{}/{}/builds'.format(url, app_id)
         body = {'image': 'foo'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
 
     def test_new_build_does_not_scale_up_automatically(self):
@@ -269,40 +258,47 @@ class BuildTest(TransactionTestCase):
         they should stay that way on a new release.
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
+
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
-        body = {'image': 'autotest/example',
-                'sha': 'a'*40,
-                'procfile': json.dumps({'web': 'node server.js',
-                                        'worker': 'node worker.js'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
+
         # scale to zero
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 204)
+
         # post another build
         url = "/v2/apps/{app_id}/builds".format(**locals())
-        body = {'image': 'autotest/example',
-                'sha': 'a'*40,
-                'procfile': json.dumps({'web': 'node server.js',
-                                        'worker': 'node worker.js'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 0)

--- a/rootfs/api/tests/test_certificate_use_case_1.py
+++ b/rootfs/api/tests/test_certificate_use_case_1.py
@@ -1,15 +1,14 @@
 import os
-import json
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Certificate, Domain
 
 
-class CertificateUseCase1Test(TestCase):
+class CertificateUseCase1Test(APITestCase):
 
     """
     Tests creation of domain SSL certificate and attach the
@@ -21,8 +20,7 @@ class CertificateUseCase1Test(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
-        self.user2 = User.objects.get(username='autotest2')
-        self.token2 = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
         self.url = '/v2/certs'
         self.app = App.objects.create(owner=self.user, id='test-app-use-case-1')
@@ -44,13 +42,11 @@ class CertificateUseCase1Test(TestCase):
         """Tests creating a certificate."""
         response = self.client.post(
             self.url,
-            json.dumps({
+            {
                 'name': self.name,
                 'certificate': self.cert,
                 'key': self.key
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            }
         )
         self.assertEqual(response.status_code, 201)
 
@@ -60,14 +56,12 @@ class CertificateUseCase1Test(TestCase):
         """
         response = self.client.post(
             self.url,
-            json.dumps({
+            {
                 'name': self.name,
                 'certificate': self.cert,
                 'key': self.key,
                 'common_name': 'foo.example.com'
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            }
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['common_name'], 'foo.com')
@@ -79,43 +73,30 @@ class CertificateUseCase1Test(TestCase):
         # Create certificate
         response = self.client.post(
             self.url,
-            json.dumps({
+            {
                 'name': self.name,
                 'certificate': self.cert,
                 'key': self.key
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            }
         )
         self.assertEqual(response.status_code, 201)
 
         # Attach to domain that does not exist
         response = self.client.post(
             '{}/{}/domain/'.format(self.url, self.name),
-            json.dumps({
-                'domain': 'random.com'
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            {'domain': 'random.com'}
         )
         self.assertEqual(response.status_code, 404)
 
         # Attach domain to certificate
         response = self.client.post(
             '{}/{}/domain/'.format(self.url, self.name),
-            json.dumps({
-                'domain': str(self.domain)
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            {'domain': str(self.domain)}
         )
         self.assertEqual(response.status_code, 201)
 
         # Assert data
-        response = self.client.get(
-            '{}/{}'.format(self.url, self.name),
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
-        )
+        response = self.client.get('{}/{}'.format(self.url, self.name))
         self.assertEqual(response.status_code, 200)
 
         expected = {
@@ -131,25 +112,20 @@ class CertificateUseCase1Test(TestCase):
 
         # detach domain to certificate
         response = self.client.delete(
-            '{}/{}/domain/{}'.format(self.url, self.name, self.domain),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            '{}/{}/domain/{}'.format(self.url, self.name, self.domain)
         )
         self.assertEqual(response.status_code, 204)
 
         # Assert data
-        response = self.client.get(
-            '{}/{}'.format(self.url, self.name),
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
-        )
+        response = self.client.get('{}/{}'.format(self.url, self.name))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
-        response = self.client.put(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(self.url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(self.url)
         self.assertEqual(response.status_code, 405)
 
     def test_delete_certificate(self):
@@ -161,7 +137,7 @@ class CertificateUseCase1Test(TestCase):
         )
 
         url = '/v2/certs/{}'.format(self.name)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
 
     def test_delete_certificate_with_attached_domain(self):
@@ -172,32 +148,23 @@ class CertificateUseCase1Test(TestCase):
         # Create certificate
         response = self.client.post(
             self.url,
-            json.dumps({
+            {
                 'name': self.name,
                 'certificate': self.cert,
                 'key': self.key
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            }
         )
         self.assertEqual(response.status_code, 201)
 
         # Attach domain to certificate
         response = self.client.post(
             '{}/{}/domain/'.format(self.url, self.name),
-            json.dumps({
-                'domain': str(self.domain)
-            }),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            {'domain': str(self.domain)}
         )
         self.assertEqual(response.status_code, 201)
 
         # Assert data from cert side
-        response = self.client.get(
-            '{}/{}'.format(self.url, self.name),
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
-        )
+        response = self.client.get('{}/{}'.format(self.url, self.name))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['domains'], [str(self.domain)])
 
@@ -207,7 +174,7 @@ class CertificateUseCase1Test(TestCase):
 
         # Delete certificate
         url = '/v2/certs/{}'.format(self.name)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
 
         # verify certificate is not attached to domain anymore

--- a/rootfs/api/tests/test_certificate_use_case_2.py
+++ b/rootfs/api/tests/test_certificate_use_case_2.py
@@ -1,15 +1,14 @@
 import os
-import json
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Certificate, Domain
 
 
-class CertificateUseCase2Test(TestCase):
+class CertificateUseCase2Test(APITestCase):
 
     """
     Tests creation of 2 domains and SSL certificate.
@@ -21,8 +20,8 @@ class CertificateUseCase2Test(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
-        self.user2 = User.objects.get(username='autotest2')
-        self.token2 = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
         self.url = '/v2/certs'
         self.app = App.objects.create(owner=self.user, id='test-app-use-case-2')
         self.domains = {
@@ -54,13 +53,11 @@ class CertificateUseCase2Test(TestCase):
         for domain, certificate in self.certificates.items():
             response = self.client.post(
                 self.url,
-                json.dumps({
+                {
                     'name': certificate['name'],
                     'certificate': certificate['cert'],
                     'key': certificate['key']
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                }
             )
             self.assertEqual(response.status_code, 201)
 
@@ -73,31 +70,24 @@ class CertificateUseCase2Test(TestCase):
             # Create certificate
             response = self.client.post(
                 self.url,
-                json.dumps({
+                {
                     'name': certificate['name'],
                     'certificate': certificate['cert'],
                     'key': certificate['key']
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                }
             )
             self.assertEqual(response.status_code, 201)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
-                json.dumps({
-                    'domain': domain
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                {'domain': domain}
             )
             self.assertEqual(response.status_code, 201)
 
             # Assert data
             response = self.client.get(
-                '{}/{}'.format(self.url, certificate['name']),
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                '{}/{}'.format(self.url, certificate['name'])
             )
             self.assertEqual(response.status_code, 200)
 
@@ -118,25 +108,20 @@ class CertificateUseCase2Test(TestCase):
 
             # detach domain to certificate
             response = self.client.delete(
-                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
             self.assertEqual(response.status_code, 204)
 
             # Assert data
-            response = self.client.get(
-                '{}/{}'.format(self.url, certificate['name']),
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
-            )
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
-        response = self.client.put(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(self.url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(self.url)
         self.assertEqual(response.status_code, 405)
 
     def test_delete_certificate(self):
@@ -149,5 +134,5 @@ class CertificateUseCase2Test(TestCase):
                 certificate=certificate['cert']
             )
             url = '/v2/certs/{}'.format(certificate['name'])
-            response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+            response = self.client.delete(url)
             self.assertEqual(response.status_code, 204)

--- a/rootfs/api/tests/test_certificate_use_case_3.py
+++ b/rootfs/api/tests/test_certificate_use_case_3.py
@@ -1,15 +1,14 @@
 import os
-import json
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Certificate, Domain
 
 
-class CertificateUseCase3Test(TestCase):
+class CertificateUseCase3Test(APITestCase):
 
     """
     Tests creation of 2 domains and 2 SSL certificate.
@@ -21,8 +20,7 @@ class CertificateUseCase3Test(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
-        self.user2 = User.objects.get(username='autotest2')
-        self.token2 = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
         self.url = '/v2/certs'
         self.app = App.objects.create(owner=self.user, id='test-app-use-case-3')
@@ -60,13 +58,11 @@ class CertificateUseCase3Test(TestCase):
         for domain, certificate in self.certificates.items():
             response = self.client.post(
                 self.url,
-                json.dumps({
+                {
                     'name': certificate['name'],
                     'certificate': certificate['cert'],
                     'key': certificate['key']
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                }
             )
             self.assertEqual(response.status_code, 201)
 
@@ -79,32 +75,23 @@ class CertificateUseCase3Test(TestCase):
             # Create certificate
             response = self.client.post(
                 self.url,
-                json.dumps({
+                {
                     'name': certificate['name'],
                     'certificate': certificate['cert'],
                     'key': certificate['key']
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                }
             )
             self.assertEqual(response.status_code, 201)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
-                json.dumps({
-                    'domain': domain
-                }),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                {'domain': domain}
             )
             self.assertEqual(response.status_code, 201)
 
             # Assert data
-            response = self.client.get(
-                '{}/{}'.format(self.url, certificate['name']),
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
-            )
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
             self.assertEqual(response.status_code, 200)
 
             expected = {
@@ -124,25 +111,20 @@ class CertificateUseCase3Test(TestCase):
 
             # detach certificate from domain
             response = self.client.delete(
-                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain),
-                content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
             self.assertEqual(response.status_code, 204)
 
             # Assert data
-            response = self.client.get(
-                '{}/{}'.format(self.url, certificate['name']),
-                HTTP_AUTHORIZATION='token {}'.format(self.token)
-            )
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
-        response = self.client.put(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(self.url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(self.url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(self.url)
         self.assertEqual(response.status_code, 405)
 
     def test_delete_certificate(self):
@@ -155,5 +137,5 @@ class CertificateUseCase3Test(TestCase):
                 certificate=certificate['cert']
             )
             url = '/v2/certs/{}'.format(certificate['name'])
-            response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+            response = self.client.delete(url)
             self.assertEqual(response.status_code, 204)

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -10,7 +10,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TransactionTestCase
+from rest_framework.test import APITransactionTestCase
 from unittest import mock
 from rest_framework.authtoken.models import Token
 
@@ -18,7 +18,7 @@ from api.models import App, Config
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-class ConfigTest(TransactionTestCase):
+class ConfigTest(APITransactionTestCase):
 
     """Tests setting and updating config values"""
 
@@ -27,6 +27,8 @@ class ConfigTest(TransactionTestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
         url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
@@ -42,82 +44,82 @@ class ConfigTest(TransactionTestCase):
         config can be updated using a PATCH
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
+
         # check to see that an initial/empty config was created
         url = "/v2/apps/{app_id}/config".format(**locals())
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('values', response.data)
         self.assertEqual(response.data['values'], {})
         config1 = response.data
+
         # set an initial config value
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         config2 = response.data
         self.assertNotEqual(config1['uuid'], config2['uuid'])
         self.assertIn('NEW_URL1', response.data['values'])
+
         # read the config
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         config3 = response.data
         self.assertEqual(config2, config3)
         self.assertIn('NEW_URL1', response.data['values'])
+
         # set an additional config value
         body = {'values': json.dumps({'NEW_URL2': 'http://localhost:8080/'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         config3 = response.data
         self.assertNotEqual(config2['uuid'], config3['uuid'])
         self.assertIn('NEW_URL1', response.data['values'])
         self.assertIn('NEW_URL2', response.data['values'])
+
         # read the config again
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         config4 = response.data
         self.assertEqual(config3, config4)
         self.assertIn('NEW_URL1', response.data['values'])
         self.assertIn('NEW_URL2', response.data['values'])
+
         # unset a config value
         body = {'values': json.dumps({'NEW_URL2': None})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         config5 = response.data
         self.assertNotEqual(config4['uuid'], config5['uuid'])
         self.assertNotIn('NEW_URL2', json.dumps(response.data['values']))
+
         # unset all config values
         body = {'values': json.dumps({'NEW_URL1': None})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertNotIn('NEW_URL1', json.dumps(response.data['values']))
+
         # disallow put/patch/delete
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
         return config5
 
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
-        response = self.client.post('/v2/apps', json.dumps(body),
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post('/v2/apps', body)
         url = "/v2/apps/test/config"
+
         # set an initial config value
         body = {'values': json.dumps({'PORT': '5000'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         for key in response.data:
             self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'values', 'memory',
                                 'cpu', 'tags'])
@@ -134,14 +136,11 @@ class ConfigTest(TransactionTestCase):
     def test_response_data_types_converted(self):
         """Test that config data is converted into the correct type."""
         body = {'id': 'test'}
-        response = self.client.post('/v2/apps', json.dumps(body),
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post('/v2/apps', body)
         url = "/v2/apps/test/config"
 
         body = {'values': json.dumps({'PORT': 5000}), 'cpu': json.dumps({'web': '1024'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         for key in response.data:
             self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'values', 'memory',
@@ -157,8 +156,7 @@ class ConfigTest(TransactionTestCase):
         self.assertDictContainsSubset(expected, response.data)
 
         body = {'cpu': json.dumps({'web': 'this will fail'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         self.assertIn('CPU shares must be a numeric value', response.data['cpu'])
 
@@ -167,20 +165,20 @@ class ConfigTest(TransactionTestCase):
         Test that config sets on the same key function properly
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = "/v2/apps/{app_id}/config".format(**locals())
+
         # set an initial config value
         body = {'values': json.dumps({'PORT': '5000'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('PORT', response.data['values'])
+
         # reset same config value
         body = {'values': json.dumps({'PORT': '5001'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('PORT', response.data['values'])
         self.assertEqual(response.data['values']['PORT'], '5001')
@@ -190,27 +188,26 @@ class ConfigTest(TransactionTestCase):
         Test that config sets with unicode values are accepted.
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = "/v2/apps/{app_id}/config".format(**locals())
+
         # set an initial config value
         body = {'values': json.dumps({'POWERED_BY': 'Деис'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('POWERED_BY', response.data['values'])
         # reset same config value
         body = {'values': json.dumps({'POWERED_BY': 'Кроликов'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('POWERED_BY', response.data['values'])
         self.assertEqual(response.data['values']['POWERED_BY'], 'Кроликов')
+
         # set an integer to test unicode regression
         body = {'values': json.dumps({'INTEGER': 1})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('INTEGER', response.data['values'])
         self.assertEqual(response.data['values']['INTEGER'], '1')
@@ -226,15 +223,13 @@ class ConfigTest(TransactionTestCase):
         """
         keys = ("FOO", "_foo", "f001", "FOO_BAR_BAZ_")
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = '/v2/apps/{app_id}/config'.format(**locals())
         for k in keys:
             body = {'values': json.dumps({k: "testvalue"})}
-            resp = self.client.post(
-                url, json.dumps(body), content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token))
+            resp = self.client.post(url, body)
             self.assertEqual(resp.status_code, 201)
             self.assertIn(k, resp.data['values'])
 
@@ -243,15 +238,13 @@ class ConfigTest(TransactionTestCase):
         """
         keys = ("123", "../../foo", "FOO/", "FOO-BAR")
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = '/v2/apps/{app_id}/config'.format(**locals())
         for k in keys:
             body = {'values': json.dumps({k: "testvalue"})}
-            resp = self.client.post(
-                url, json.dumps(body), content_type='application/json',
-                HTTP_AUTHORIZATION='token {}'.format(self.token))
+            resp = self.client.post(url, body)
             self.assertEqual(resp.status_code, 400)
 
     def test_admin_can_create_config_on_other_apps(self):
@@ -261,14 +254,16 @@ class ConfigTest(TransactionTestCase):
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user).key
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = "/v2/apps/{app_id}/config".format(**locals())
+
         # set an initial config value
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         body = {'values': json.dumps({'PORT': '5000'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('PORT', response.data['values'])
         return response
@@ -279,37 +274,37 @@ class ConfigTest(TransactionTestCase):
         limits can be updated using a PATCH
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = '/v2/apps/{app_id}/config'.format(**locals())
+
         # check default limit
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('memory', response.data)
         self.assertEqual(response.data['memory'], {})
         # regression test for https://github.com/deis/deis/issues/1563
         self.assertNotIn('"', response.data['memory'])
+
         # set an initial limit
         mem = {'web': '1G'}
         body = {'memory': json.dumps(mem)}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit1 = response.data
+
         # check memory limits
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('memory', response.data)
         memory = response.data['memory']
         self.assertIn('web', memory)
         self.assertEqual(memory['web'], '1G')
+
         # set an additional value
         body = {'memory': json.dumps({'worker': '512M'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit2 = response.data
         self.assertNotEqual(limit1['uuid'], limit2['uuid'])
@@ -318,8 +313,9 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(memory['worker'], '512M')
         self.assertIn('web', memory)
         self.assertEqual(memory['web'], '1G')
+
         # read the limit again
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         limit3 = response.data
         self.assertEqual(limit2, limit3)
@@ -328,35 +324,37 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(memory['worker'], '512M')
         self.assertIn('web', memory)
         self.assertEqual(memory['web'], '1G')
+
         # regression test for https://github.com/deis/deis/issues/1613
         # ensure that config:set doesn't wipe out previous limits
         body = {'values': json.dumps({'NEW_URL2': 'http://localhost:8080/'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('NEW_URL2', response.data['values'])
+
         # read the limit again
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         memory = response.data['memory']
         self.assertIn('worker', memory)
         self.assertEqual(memory['worker'], '512M')
         self.assertIn('web', memory)
         self.assertEqual(memory['web'], '1G')
+
         # unset a value
         body = {'memory': json.dumps({'worker': None})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit4 = response.data
         self.assertNotEqual(limit3['uuid'], limit4['uuid'])
         self.assertNotIn('worker', json.dumps(response.data['memory']))
+
         # disallow put/patch/delete
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
         return limit4
 
@@ -365,36 +363,36 @@ class ConfigTest(TransactionTestCase):
         Test that CPU limits can be set
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         url = '/v2/apps/{app_id}/config'.format(**locals())
+
         # check default limit
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('cpu', response.data)
         self.assertEqual(response.data['cpu'], {})
         # regression test for https://github.com/deis/deis/issues/1563
         self.assertNotIn('"', response.data['cpu'])
+
         # set an initial limit
         body = {'cpu': json.dumps({'web': '1024'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit1 = response.data
+
         # check memory limits
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('cpu', response.data)
         cpu = response.data['cpu']
         self.assertIn('web', cpu)
         self.assertEqual(cpu['web'], '1024')
+
         # set an additional value
         body = {'cpu': json.dumps({'worker': '512'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit2 = response.data
         self.assertNotEqual(limit1['uuid'], limit2['uuid'])
@@ -403,8 +401,9 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(cpu['worker'], '512')
         self.assertIn('web', cpu)
         self.assertEqual(cpu['web'], '1024')
+
         # read the limit again
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         limit3 = response.data
         self.assertEqual(limit2, limit3)
@@ -413,20 +412,21 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(cpu['worker'], '512')
         self.assertIn('web', cpu)
         self.assertEqual(cpu['web'], '1024')
+
         # unset a value
         body = {'memory': json.dumps({'worker': None})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         limit4 = response.data
         self.assertNotEqual(limit3['uuid'], limit4['uuid'])
         self.assertNotIn('worker', json.dumps(response.data['memory']))
+
         # disallow put/patch/delete
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
         return limit4
 
@@ -435,35 +435,34 @@ class ConfigTest(TransactionTestCase):
         Test that tags can be set on an application
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
 
         # check default
         url = '/v2/apps/{app_id}/config'.format(**locals())
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('tags', response.data)
         self.assertEqual(response.data['tags'], {})
+
         # set some tags
         body = {'tags': json.dumps({'environ': 'dev'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         tags1 = response.data
+
         # check tags again
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('tags', response.data)
         tags = response.data['tags']
         self.assertIn('environ', tags)
         self.assertEqual(tags['environ'], 'dev')
+
         # set an additional value
         body = {'tags': json.dumps({'rack': '1'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         tags2 = response.data
         self.assertNotEqual(tags1['uuid'], tags2['uuid'])
@@ -472,8 +471,9 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(tags['rack'], '1')
         self.assertIn('environ', tags)
         self.assertEqual(tags['environ'], 'dev')
+
         # read the limit again
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         tags3 = response.data
         self.assertEqual(tags2, tags3)
@@ -482,58 +482,53 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(tags['rack'], '1')
         self.assertIn('environ', tags)
         self.assertEqual(tags['environ'], 'dev')
+
         # unset a value
         body = {'tags': json.dumps({'rack': None})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         tags4 = response.data
         self.assertNotEqual(tags3['uuid'], tags4['uuid'])
         self.assertNotIn('rack', json.dumps(response.data['tags']))
+
         # set valid values
         body = {'tags': json.dumps({'kubernetes.io/hostname': '172.17.8.100'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         body = {'tags': json.dumps({'is.valid': 'is-also_valid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         body = {'tags': json.dumps({'host.the-name.com/is.valid': 'valid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         body = {'tags': json.dumps({'host.the-name.com/does.no.exist': 'valid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertContains(
             response,
             'Addition of host.the-name.com/does.no.exist=valid is the cause',
             status_code=400
         )
+
         # set invalid values
         body = {'tags': json.dumps({'valid': 'in\nvalid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         body = {'tags': json.dumps({'host.name.com/notvalid-': 'valid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         body = {'tags': json.dumps({'valid': 'invalid.'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         body = {'tags': json.dumps({'host.name.com/,not.valid': 'valid'})}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
+
         # disallow put/patch/delete
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
 
     def test_config_owner_is_requesting_user(self):
@@ -554,14 +549,14 @@ class ConfigTest(TransactionTestCase):
         app_id = 'autotest'
         base_url = '/v2/apps'
         body = {'id': app_id}
-        response = self.client.post(base_url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(base_url, body)
+
         unauthorized_user = User.objects.get(username='autotest2')
         unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
         url = '{}/{}/config'.format(base_url, app_id)
         body = {'values': {'FOO': 'bar'}}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
 
     def test_healthchecks(self):
@@ -569,7 +564,7 @@ class ConfigTest(TransactionTestCase):
         Test that healthchecks can be applied
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
 
@@ -577,9 +572,7 @@ class ConfigTest(TransactionTestCase):
         body = {'values': json.dumps({'HEALTHCHECK_URL': '/health'})}
         resp = self.client.post(
             '/v2/apps/{app_id}/config'.format(**locals()),
-            json.dumps(body),
-            content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token)
+            body
         )
         self.assertEqual(resp.status_code, 201)
         self.assertIn('HEALTHCHECK_URL', resp.data['values'])
@@ -588,6 +581,5 @@ class ConfigTest(TransactionTestCase):
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)

--- a/rootfs/api/tests/test_healthcheck.py
+++ b/rootfs/api/tests/test_healthcheck.py
@@ -1,8 +1,8 @@
 
-from django.test import TestCase
+from rest_framework.test import APITestCase
 
 
-class HealthCheckTest(TestCase):
+class HealthCheckTest(APITestCase):
 
     def setUp(self):
         self.url = '/healthz'

--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -4,13 +4,9 @@ Unit tests for the Deis api app.
 
 Run the tests with "./manage.py test api"
 """
-
-
-import json
-
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import Key
@@ -52,7 +48,7 @@ BAD_KEY = (
 )
 
 
-class KeyTest(TestCase):
+class KeyTest(APITestCase):
 
     """Tests cloud provider credentials"""
 
@@ -61,6 +57,7 @@ class KeyTest(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
     def tearDown(self):
         # make sure every test has a clean slate for k8s mocking
@@ -72,22 +69,21 @@ class KeyTest(TestCase):
         """
         url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         key_id = response.data['id']
 
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
 
         url = '/v2/keys/{key_id}'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body['id'], response.data['id'])
         self.assertEqual(body['public'], response.data['public'])
 
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
 
     def _check_bad_key(self, pubkey):
@@ -96,8 +92,8 @@ class KeyTest(TestCase):
         """
         url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         return response
 
@@ -117,20 +113,16 @@ class KeyTest(TestCase):
         """
         url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         # test that adding a key with the same fingerprint fails
         body = {'id': 'mykey2@box.local', 'public': pubkey}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400)
         body = {'id': 'mykey2@box.local', 'public': pubkey2}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
 
     def test_rsa_duplicate_key(self):
@@ -150,8 +142,7 @@ class KeyTest(TestCase):
                 'HdQGho20pfJktNu7DxeVkTHn9REMUphf85su7slTgTlWKq++3fASE8PdmFGz'
                 'b6PkOR4c+LS5WWXd2oM6HyBQBxxiwXbA2lSgQxOdgDiM2FzT0GVSFMUklkUH'
                 'MdsaG6/HJDw9QckTS0vN autotest@deis.io'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         key = Key.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(key), 'ssh-rsa AAAAB3NzaC.../HJDw9QckTS0vN autotest@deis.io')

--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -1,12 +1,9 @@
-
-import json
-
 from django.contrib.auth.models import User
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 
-class TestAdminPerms(TestCase):
+class TestAdminPerms(APITestCase):
 
     def test_first_signup(self):
         # register a first user
@@ -18,9 +15,10 @@ class TestAdminPerms(TestCase):
             'email': email,
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
+
         # register a second user
         username, password = 'seconduser', 'password'
         email = 'autotest@deis.io'
@@ -30,7 +28,7 @@ class TestAdminPerms(TestCase):
             'email': email,
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
 
@@ -41,17 +39,20 @@ class TestAdminPerms(TestCase):
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
+
         user = User.objects.get(username='firstuser')
         token = Token.objects.get(user=user).key
-        response = self.client.get('/v2/admin/perms', content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        response = self.client.get('/v2/admin/perms')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['username'], 'firstuser')
         self.assertTrue(response.data['results'][0]['is_superuser'])
+
         # register a non-superuser
         submit = {
             'username': 'seconduser',
@@ -59,13 +60,15 @@ class TestAdminPerms(TestCase):
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
+
         user = User.objects.get(username='seconduser')
         token = Token.objects.get(user=user).key
-        response = self.client.get('/v2/admin/perms', content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        response = self.client.get('/v2/admin/perms')
         self.assertEqual(response.status_code, 403)
         self.assertIn('You do not have permission', response.data['detail'])
 
@@ -76,27 +79,29 @@ class TestAdminPerms(TestCase):
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
+
         submit = {
             'username': 'second',
             'password': 'password',
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
+
         user = User.objects.get(username='first')
         token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         # grant user 2 the superuser perm
         url = '/v2/admin/perms'
         body = {'username': 'second'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         self.assertIn('second', str(response.data['results']))
@@ -108,42 +113,48 @@ class TestAdminPerms(TestCase):
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
+
         submit = {
             'username': 'second',
             'password': 'password',
             'email': 'autotest@deis.io',
         }
         url = '/v2/auth/register'
-        response = self.client.post(url, json.dumps(submit), content_type='application/json')
+        response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
+
         user = User.objects.get(username='first')
         token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         # grant user 2 the superuser perm
         url = '/v2/admin/perms'
         body = {'username': 'second'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         # revoke the superuser perm
-        response = self.client.delete(url + '/second', HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.delete(url + '/second')
         self.assertEqual(response.status_code, 204)
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         self.assertNotIn('two', str(response.data['results']))
 
 
-class TestAppPerms(TestCase):
+class TestAppPerms(APITestCase):
 
     fixtures = ['test_sharing.json']
 
     def setUp(self):
         self.user = User.objects.get(username='autotest-1')
         self.token = Token.objects.get(user=self.user).key
+        # Always have first user authed coming into tests
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
         self.user2 = User.objects.get(username='autotest-2')
         self.token2 = Token.objects.get(user=self.user2).key
         self.user3 = User.objects.get(username='autotest-3')
@@ -151,111 +162,121 @@ class TestAppPerms(TestCase):
 
     def test_create(self):
         # check that user 1 sees her lone app and user 2's app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
+
         # check that user 2 can only see his app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.get('/v2/apps')
         self.assertEqual(len(response.data['results']), 1)
         # check that user 2 can't see any of the app's builds, configs,
         # containers, limits, or releases
         for model in ['builds', 'config', 'containers', 'releases']:
-            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model),
-                                       HTTP_AUTHORIZATION='token {}'.format(self.token2))
+            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model))
             msg = "Failed: status '%s', and data '%s'" % (response.status_code, response.data)
             self.assertEqual(response.status_code, 403, msg=msg)
             self.assertEqual(response.data['detail'],
                              'You do not have permission to perform this action.', msg=msg)
+
         # TODO: test that git pushing to the app fails
         # give user 2 permission to user 1's app
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         # check that user 2 can see the app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
+
         # check that user 2 sees (empty) results now for builds, containers,
         # and releases. (config and limit will still give 404s since we didn't
         # push a build here.)
         for model in ['builds', 'releases']:
-            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model),
-                                       HTTP_AUTHORIZATION='token {}'.format(self.token2))
+            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model))
             self.assertEqual(len(response.data['results']), 0)
         # TODO:  check that user 2 can git push the app
 
     def test_create_errors(self):
         # check that user 1 sees her lone app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         app_id = response.data['results'][0]['id']
+
         # check that user 2 can't create a permission
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
 
     def test_delete(self):
         # give user 2 permission to user 1's app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         app_id = response.data['results'][0]['id']
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         # check that user 2 can see the app as well as his own
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
+
         # delete permission to user 1's app
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         url = "/v2/apps/{}/perms/{}".format(app_id, 'autotest-2')
-        response = self.client.delete(url, content_type='application/json',
-                                      HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
         self.assertIsNone(response.data)
+
         # check that user 2 can only see his app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.get('/v2/apps')
         self.assertEqual(len(response.data['results']), 1)
+
         # delete permission to user 1's app again, expecting an error
-        response = self.client.delete(url, content_type='application/json',
-                                      HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 403)
 
     def test_list(self):
         # check that user 1 sees her lone app and user 2's app
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
+
         # create a new object permission
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         # list perms on the app
-        response = self.client.get(
-            "/v2/apps/{}/perms".format(app_id), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get("/v2/apps/{}/perms".format(app_id))
         self.assertEqual(response.data, {'users': ['autotest-2']})
 
     def test_admin_can_list(self):
         """Check that an administrator can list an app's perms"""
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
 
     def test_list_errors(self):
-        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps')
         app_id = response.data['results'][0]['id']
+
         # login as user 2, list perms on the app
-        response = self.client.get(
-            "/v2/apps/{}/perms".format(app_id), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.get("/v2/apps/{}/perms".format(app_id))
         self.assertEqual(response.status_code, 403)
 
     def test_unauthorized_user_cannot_modify_perms(self):
@@ -268,14 +289,12 @@ class TestAppPerms(TestCase):
         app_id = 'autotest'
         url = '/v2/apps'
         body = {'id': app_id}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
-        unauthorized_user = self.user2
-        unauthorized_token = self.token2
+        response = self.client.post(url, body)
+
         url = '{}/{}/perms'.format(url, app_id)
-        body = {'username': unauthorized_user.username}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        body = {'username': self.user2.username}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
 
     def test_collaborator_cannot_share(self):
@@ -287,32 +306,38 @@ class TestAppPerms(TestCase):
         collab = self.user2
         collab_token = self.token2
         url = '/v2/apps/{}/perms'.format(app_id)
+
         # Share app with collaborator
         body = {'username': collab.username}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(owner_token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
+
         # Collaborator should fail to share app
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + collab_token)
         body = {'username': self.user3.username}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(collab_token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
+
         # Collaborator can list
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(collab_token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
         # Share app with user 3 for rest of tests
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(owner_token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(collab_token))
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + collab_token)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
         # Collaborator cannot delete other collaborator
         url += "/{}".format(self.user3.username)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(collab_token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 403)
+
         # Collaborator can delete themselves
         url = '/v2/apps/{}/perms/{}'.format(app_id, collab.username)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(collab_token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -10,7 +10,7 @@ import uuid
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TransactionTestCase
+from rest_framework.test import APITransactionTestCase
 from unittest import mock
 from rest_framework.authtoken.models import Token
 
@@ -18,7 +18,7 @@ from api.models import Release
 
 
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-class ReleaseTest(TransactionTestCase):
+class ReleaseTest(APITransactionTestCase):
 
     """Tests push notification from build system"""
 
@@ -27,6 +27,7 @@ class ReleaseTest(TransactionTestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
     def tearDown(self):
         # make sure every test has a clean slate for k8s mocking
@@ -38,25 +39,23 @@ class ReleaseTest(TransactionTestCase):
         that updating config or build or triggers a new release
         """
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # check that updating config rolls a new release
         url = '/v2/apps/{app_id}/config'.format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('NEW_URL1', response.data['values'])
         # check to see that an initial release was created
         url = '/v2/apps/{app_id}/releases'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # account for the config release as well
         self.assertEqual(response.data['count'], 2)
         url = '/v2/apps/{app_id}/releases/v1'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release1 = response.data
         self.assertIn('config', response.data)
@@ -64,7 +63,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(release1['version'], 1)
         # check to see that a new release was created
         url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release2 = response.data
         self.assertNotEqual(release1['uuid'], release2['uuid'])
@@ -75,14 +74,12 @@ class ReleaseTest(TransactionTestCase):
         url = '/v2/apps/{app_id}/builds'.format(**locals())
         build_config = json.dumps({'PATH': 'bin:/usr/local/bin:/usr/bin:/bin'})
         body = {'image': 'autotest/example'}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['image'], body['image'])
         # check to see that a new release was created
         url = '/v2/apps/{app_id}/releases/v3'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release3 = response.data
         self.assertNotEqual(release2['uuid'], release3['uuid'])
@@ -90,7 +87,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(release3['version'], 3)
         # check that we can fetch a previous release
         url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release2 = response.data
         self.assertNotEqual(release2['uuid'], release3['uuid'])
@@ -98,27 +95,23 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(release2['version'], 2)
         # disallow post/put/patch/delete
         url = '/v2/apps/{app_id}/releases'.format(**locals())
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.put(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.put(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.patch(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 405)
         return release3
 
     def test_response_data(self):
         body = {'id': 'test'}
-        response = self.client.post('/v2/apps', json.dumps(body),
-                                    content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post('/v2/apps', body,)
         body = {'values': json.dumps({'NEW_URL': 'http://localhost:8080/'})}
-        config_response = self.client.post('/v2/apps/test/config', json.dumps(body),
-                                           content_type='application/json',
-                                           HTTP_AUTHORIZATION='token {}'.format(self.token))
+        config_response = self.client.post('/v2/apps/test/config', body)
         url = '/v2/apps/test/releases/v2'
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         for key in response.data.keys():
             self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'build', 'config',
                                 'summary', 'version'])
@@ -134,51 +127,42 @@ class ReleaseTest(TransactionTestCase):
 
     def test_release_rollback(self):
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # try to rollback with only 1 release extant, expecting 400
         url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
-        response = self.client.post(url, content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {'detail': 'version cannot be below 0'})
         self.assertEqual(response.get('content-type'), 'application/json')
         # update config to roll a new release
         url = '/v2/apps/{app_id}/config'.format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         #  todo : edge case that fails becasue version 1 has no build object.
         # update the build to roll a new release
         # url = '/v2/apps/{app_id}/builds'.format(**locals())
         # body = {'image': 'autotest/example'}
-        # response = self.client.post(
-        #     url, json.dumps(body), content_type='application/json',
-        #     HTTP_AUTHORIZATION='token {}'.format(self.token))
+        # response = self.client.post(url, body)
         # self.assertEqual(response.status_code, 201)
         # rollback and check to see that a 4th release was created
         # with the build and config of release #2
         url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
-        response = self.client.post(url, content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         url = '/v2/apps/{app_id}/releases'.format(**locals())
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 3)
         url = '/v2/apps/{app_id}/releases/v1'.format(**locals())
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release1 = response.data
         self.assertEqual(release1['version'], 1)
         url = '/v2/apps/{app_id}/releases/v3'.format(**locals())
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release3 = response.data
         self.assertEqual(release3['version'], 3)
@@ -189,21 +173,18 @@ class ReleaseTest(TransactionTestCase):
         # was created with the build and config of release #1
         url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
         body = {'version': 1}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         url = '/v2/apps/{app_id}/releases'.format(**locals())
-        response = self.client.get(url, content_type='application/json',
-                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 4)
         url = '/v2/apps/{app_id}/releases/v1'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release1 = response.data
         url = '/v2/apps/{app_id}/releases/v4'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         release4 = response.data
         self.assertEqual(release4['version'], 4)
@@ -212,18 +193,16 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(release1['config'], release4['config'])
         # check to see that the current config is actually the initial one
         url = "/v2/apps/{app_id}/config".format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['values'], {})
         # rollback to #2 and see that it has the correct config
         url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
         body = {'version': 2}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         url = "/v2/apps/{app_id}/config".format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         values = response.data['values']
         self.assertIn('NEW_URL1', values)
@@ -247,20 +226,20 @@ class ReleaseTest(TransactionTestCase):
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user).key
         url = '/v2/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # check that updating config rolls a new release
         url = '/v2/apps/{app_id}/config'.format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201)
         self.assertIn('NEW_URL1', response.data['values'])
         # check to see that an initial release was created
         url = '/v2/apps/{app_id}/releases'.format(**locals())
-        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # account for the config release as well
         self.assertEqual(response.data['count'], 2)
@@ -275,23 +254,22 @@ class ReleaseTest(TransactionTestCase):
         app_id = 'autotest'
         base_url = '/v2/apps'
         body = {'id': app_id}
-        response = self.client.post(base_url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(base_url, body)
+
         # push a new build
         url = '{base_url}/{app_id}/builds'.format(**locals())
         body = {'image': 'test'}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
+
         # update config to roll a new release
         url = '{base_url}/{app_id}/config'.format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
-        response = self.client.post(
-            url, json.dumps(body), content_type='application/json',
-            HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.post(url, body)
         unauthorized_user = User.objects.get(username='autotest2')
         unauthorized_token = Token.objects.get(user=unauthorized_user).key
+
         # try to rollback
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
         url = '{base_url}/{app_id}/releases/rollback/'.format(**locals())
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 403)

--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -1,11 +1,11 @@
 
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
 
-class TestUsers(TestCase):
+class TestUsers(APITestCase):
     """ Tests users endpoint"""
 
     fixtures = ['tests.json']


### PR DESCRIPTION
Simplifies many calls

By setting a default DRF testing format (was already done in the settings file anyway), moving to using APITestCase and friends, plus credentials / login then the tests overall look cleaner and in many cases easier to grok

More information is at http://www.django-rest-framework.org/api-guide/testing/

Note that there is no need to use `json.dumps` when sending data as DRF takes care of that