### PR TITLE
fix(boot): make wsgi aware of what settings file to use (production)

### DIFF
--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -38,6 +38,7 @@ class HealthCheckView(View):
                 c.execute("SELECT 0")
         except django.db.Error as e:
             logger.critical("Database health check failed")
+            # FIXME why is turning on DEBUG=true in env not outputting this error?
             logger.debug(str(e))
 
             return HttpResponse(

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -33,7 +33,7 @@ echo "Database Migrations:"
 sudo -E -u deis python /app/manage.py migrate --settings deis.production --noinput
 
 # spawn a gunicorn server in the background
-sudo -E -u deis gunicorn -c /app/deis/gconf.py deis.wsgi &
+sudo -E -u deis gunicorn --env DJANGO_SETTINGS_MODULE=deis.production -c /app/deis/gconf.py deis.wsgi &
 
 python /app/manage.py load_db_state_to_k8s --settings deis.production
 


### PR DESCRIPTION
boot script and friends worked just fine because the settings were passed to it but wsgi.py auto uses settings.py if nothing else is passed in