### PR TITLE
feat(permissions): add option to disable app creation for normal users.

### DIFF
--- a/rootfs/api/permissions.py
+++ b/rootfs/api/permissions.py
@@ -19,6 +19,16 @@ def is_app_user(request, obj):
         return False
 
 
+def can_create_app(request):
+    """
+    Return `True` if user can create app, `False` otherwise.
+    """
+    if request.user.is_superuser:
+        return True
+    else:
+        return not settings.DISABLE_APP_CREATION
+
+
 class IsAnonymous(permissions.BasePermission):
     """
     View permission to allow anonymous users.

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -196,6 +196,12 @@ class AppViewSet(BaseDeisViewSet):
     def get_queryset(self, *args, **kwargs):
         return self.model.objects.all(*args, **kwargs)
 
+    def create(self, request, **kwargs):
+        if not permissions.can_create_app(request):
+            raise PermissionDenied()
+
+        return super(AppViewSet, self).create(request, **kwargs)
+
     def list(self, request, *args, **kwargs):
         """
         HACK: Instead of filtering by the queryset, we limit the queryset to list only the apps

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -284,6 +284,10 @@ ROUTER_PORT = os.environ.get('DEIS_ROUTER_SERVICE_PORT', 80)
 # check if we can register users with `deis register`
 REGISTRATION_MODE = os.environ.get('REGISTRATION_MODE', 'enabled')
 
+# check if app creation is disabled for normal users
+DISABLE_APP_CREATION = os.environ.get('DISABLE_APP_CREATION', False)
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
This adds a environmental variable toggle (`$DISABLE_APP_CREATION`) to restrict app creation to administrators only.

This my start in re-implementing some of the features in deis/deis#4265 and the proposal deis/deis#4150

Fixes deis/deis#4052

If this is the right approach, I'll start implementing some of the other feature flags in deis/deis#4150.