### PR TITLE
feat(scheduler): store env vars as secrets in k8s and map them in the RC

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -535,7 +535,8 @@ class App(UuidAuditedModel):
             'memory': release.config.memory,
             'cpu': release.config.cpu,
             'tags': release.config.tags,
-            'envs': release.config.values
+            'envs': release.config.values,
+            'version': "v{}".format(release.version),
         }
 
         try:


### PR DESCRIPTION
This provides more security around sensitive information and lets k8s admins put more controls in place on who can update what

Went with a secret per release instead of a secret per app that we keep updating. Thoughts on that?

Closes #299