### PR TITLE
fix(controller): use django HttpResponse for logs

### DIFF
--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -108,7 +108,10 @@ class AppTest(APITestCase):
         # test logs - unanticipated status code from deis-logger
         mock_response.status_code = 400
         response = self.client.get(url)
-        self.assertContains(response, "Error accessing logs for {}".format(app_id), status_code=500)
+        self.assertContains(
+            response,
+            "Error accessing logs for {}".format(app_id),
+            status_code=500)
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
@@ -119,7 +122,10 @@ class AppTest(APITestCase):
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url)
-        self.assertContains(response, "Error accessing logs for {}".format(app_id), status_code=500)
+        self.assertContains(
+            response,
+            "Error accessing logs for {}".format(app_id),
+            status_code=500)
 
         # TODO: test run needs an initial build
 

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -108,21 +108,18 @@ class AppTest(APITestCase):
         # test logs - unanticipated status code from deis-logger
         mock_response.status_code = 400
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 500)
-        self.assertContains(response, "Error accessing logs for {}".format(app_id))
+        self.assertContains(response, "Error accessing logs for {}".format(app_id), status_code=500)
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
         mock_response.content = FAKE_LOG_DATA
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, FAKE_LOG_DATA)
+        self.assertContains(response, FAKE_LOG_DATA, status_code=200)
 
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 500)
-        self.assertContains(response, "Error accessing logs for {}".format(app_id))
+        self.assertContains(response, "Error accessing logs for {}".format(app_id), status_code=500)
 
         # TODO: test run needs an initial build
 

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -99,32 +99,30 @@ class AppTest(APITestCase):
         url = "/v2/apps/{app_id}/logs".format(**locals())
         response = self.client.get(url)
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - 404 from deis-logger
         mock_response.status_code = 404
         response = self.client.get(url)
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - unanticipated status code from deis-logger
         mock_response.status_code = 400
         response = self.client.get(url)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
+        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
         mock_response.content = FAKE_LOG_DATA
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, FAKE_LOG_DATA)
+        self.assertEqual(response.content, FAKE_LOG_DATA)
 
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
+        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
 
         # TODO: test run needs an initial build
 

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -109,20 +109,20 @@ class AppTest(APITestCase):
         mock_response.status_code = 400
         response = self.client.get(url)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
+        self.assertContains(response, "Error accessing logs for {}".format(app_id))
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
         mock_response.content = FAKE_LOG_DATA
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, FAKE_LOG_DATA)
+        self.assertContains(response, FAKE_LOG_DATA)
 
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
+        self.assertContains(response, "Error accessing logs for {}".format(app_id))
 
         # TODO: test run needs an initial build
 

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -234,22 +234,20 @@ class AppViewSet(BaseDeisViewSet):
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            return Response(app.logs(request.query_params.get('log_lines',
-                                     str(settings.LOG_LINES))),
-                            status=status.HTTP_200_OK, content_type='text/plain')
+            return HttpResponse(app.logs(request.query_params.get('log_lines',
+                                         str(settings.LOG_LINES))),
+                                status=status.HTTP_200_OK, content_type='text/plain')
         except requests.exceptions.RequestException:
-            return Response("Error accessing logs for {}".format(app.id),
-                            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            content_type='text/plain')
-        except EnvironmentError as e:
-            if str(e) == 'Error accessing deis-logger':
-                return Response("Error accessing logs for {}".format(app.id),
+            return HttpResponse("Error accessing logs for {}".format(app.id),
                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                                 content_type='text/plain')
+        except EnvironmentError as e:
+            if str(e) == 'Error accessing deis-logger':
+                return HttpResponse("Error accessing logs for {}".format(app.id),
+                                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                    content_type='text/plain')
             else:
-                return Response("No logs for {}".format(app.id),
-                                status=status.HTTP_204_NO_CONTENT,
-                                content_type='text/plain')
+                return HttpResponse(status=status.HTTP_204_NO_CONTENT)
 
     def run(self, request, **kwargs):
         app = self.get_object()


### PR DESCRIPTION
Django Rest Framework will wrap the string with quotes because
of the JSONRenderer. Django's HttpResponse class handles the
application logs as we expect it to.

this is a port of deis/deis#5004

related PRs: deis/workflow-cli#33 and deis/workflow#132