### PR TITLE
chore(requirements): update django-guardian to 1.4.4

### DIFF
--- a/rootfs/api/fixtures/test_sharing.json
+++ b/rootfs/api/fixtures/test_sharing.json
@@ -1,23 +1,5 @@
 [
 {
-  "pk": -1,
-  "model": "auth.user",
-  "fields": {
-    "username": "AnonymousUser",
-    "first_name": "",
-    "last_name": "",
-    "is_active": true,
-    "is_superuser": false,
-    "is_staff": false,
-    "last_login": "2013-11-25T21:33:19.120Z",
-    "groups": [],
-    "user_permissions": [],
-    "password": "",
-    "email": "",
-    "date_joined": "2013-11-25T21:33:19.120Z"
-  }
-},
-{
   "pk": 2,
   "model": "auth.user",
   "fields": {

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -2,7 +2,7 @@
 #
 Django==1.9.5
 django-cors-headers==1.1.0
-django-guardian==1.4.1
+django-guardian==1.4.4
 djangorestframework==3.3.3
 docker-py==1.8.0
 gunicorn==19.4.5


### PR DESCRIPTION
See https://github.com/django-guardian/django-guardian/blob/devel/CHANGES
and https://github.com/django-guardian/django-guardian/compare/v1.4.1...v1.4.4

This PR also removes `AnonymousUser` from a test fixture to cooperate with the newer django-guardian library.