### PR TITLE
fix(deploy): catch Exception instead of RuntimeError

### DIFF
--- a/rootfs/api/models/build.py
+++ b/rootfs/api/models/build.py
@@ -43,7 +43,7 @@ class Build(UuidAuditedModel):
         try:
             self.app.deploy(user, new_release)
             return new_release
-        except RuntimeError:
+        except Exception:
             if 'new_release' in locals():
                 new_release.delete()
             raise

--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -115,7 +115,7 @@ class Release(UuidAuditedModel):
             if self.build is not None:
                 self.app.deploy(user, new_release)
             return new_release
-        except RuntimeError:
+        except Exception:
             if 'new_release' in locals():
                 new_release.delete()
             raise

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -316,7 +316,7 @@ class ConfigViewSet(ReleasableViewSet):
             # It's possible to set config values before a build
             if self.release.build is not None:
                 config.app.deploy(self.request.user, self.release)
-        except RuntimeError:
+        except Exception:
             self.release.delete()
             raise
 


### PR DESCRIPTION
In the deploy function Exception is caught, problem logged and then re-raised. Best to catch Exception as well to clean up the release object around it

Potentially affects the following tickets:
#410, #319, #187, #320