### PR TITLE
chore(requirements): update pyOpenSSL to 16.0.0

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,7 +10,7 @@ jsonfield==1.0.3
 morph==0.1.2
 ndg-httpsclient==0.4.0
 psycopg2==2.6.1
-PyOpenSSL==0.15.1
+pyOpenSSL==16.0.0
 pytz==2016.3
 PyYAML==3.11
 requests==2.9.1


### PR DESCRIPTION
See https://pyopenssl.readthedocs.org/en/stable/changelog.html#id1