### PR TITLE
fix(deploy): use the passed in scale of a proc type for deploy

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -297,7 +297,7 @@ class App(UuidAuditedModel):
     def _scale_pods(self, scale_types):
         release = self.release_set.latest()
         build_type = app_build_type(release)
-        for scale_type in scale_types:
+        for scale_type, replicas in scale_types.items():
             image = release.image
             version = "v{}".format(release.version)
             kwargs = {
@@ -306,7 +306,7 @@ class App(UuidAuditedModel):
                 'tags': release.config.tags,
                 'envs': release.config.values,
                 'version': version,
-                'replicas': scale_types[scale_type],
+                'replicas': replicas,
                 'app_type': scale_type,
                 'build_type': build_type,
                 'healthcheck': release.config.healthcheck(),
@@ -344,13 +344,14 @@ class App(UuidAuditedModel):
         # deploy application to k8s. Also handles initial scaling
         deploys = {}
         build_type = app_build_type(release)
-        for scale_type in self.structure.keys():
+        for scale_type, replicas in self.structure.items():
             deploys[scale_type] = {
                 'memory': release.config.memory,
                 'cpu': release.config.cpu,
                 'tags': release.config.tags,
                 'envs': release.config.values,
-                'replicas': 0,  # Scaling up happens in a separate operation
+                # only used if there is no previous RC
+                'replicas': replicas,
                 'version': "v{}".format(release.version),
                 'app_type': scale_type,
                 'build_type': build_type,

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -346,9 +346,11 @@ class KubeHTTPClient(object):
         new_rc = self._create_rc(namespace, name, image, command, **kwargs)
 
         # Get the desired number to scale to
-        desired = 1
         if old_rc:
             desired = int(old_rc["spec"]["replicas"])
+        else:
+            desired = kwargs['replicas']
+            logger.debug('No prior RC could be found for {}-{}'.format(namespace, app_type))
 
         try:
             count = 1


### PR DESCRIPTION
Before a scale of 1 was hard coded if an old RC could not be found, instead of that use information from the structure in the App model which already defaults to 1 on first deploy

Fixes #607