### PR TITLE
chore(.travis.yml): update test PostgreSQL to 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - postgresql
 sudo: required
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 before_install:
   - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
   - sudo dpkg -i shellcheck_0.3.7-5_amd64.deb


### PR DESCRIPTION
This is closer to parity with v9.4.6 currently in use by the [deis/postgres](https://github.com/deis/postgres) component.