### PR TITLE
fix(docker): bubble up docker errors from the internal docker client

### DIFF
--- a/rootfs/registry/__init__.py
+++ b/rootfs/registry/__init__.py
@@ -1,1 +1,1 @@
-from .dockerclient import publish_release  # noqa
+from .dockerclient import publish_release, RegistryException  # noqa

--- a/rootfs/registry/tests.py
+++ b/rootfs/registry/tests.py
@@ -33,7 +33,8 @@ class DockerClientTest(unittest.TestCase):
         self.client.publish_release('ozzy/embryo:git-f2a8020', 'quay.io/ozzy/embryo:v4', True)
         docker_push = self.client.client.push
         docker_push.assert_called_with(
-            'localhost:5000/ozzy/embryo', tag='v4', insecure_registry=True, stream=True)
+            'localhost:5000/ozzy/embryo', tag='v4', insecure_registry=True,
+            decode=True, stream=True)
         # Test that blacklisted image names can't be published
         with self.assertRaises(PermissionDenied):
             self.client.publish_release(
@@ -47,7 +48,7 @@ class DockerClientTest(unittest.TestCase):
         self.client.pull('alpine', '3.2')
         docker_pull = self.client.client.pull
         docker_pull.assert_called_once_with(
-            'alpine', tag='3.2', insecure_registry=True, stream=True)
+            'alpine', tag='3.2', insecure_registry=True, decode=True, stream=True)
         # Test that blacklisted image names can't be pulled
         with self.assertRaises(PermissionDenied):
             self.client.pull('deis/controller', 'v1.11.1')
@@ -59,7 +60,7 @@ class DockerClientTest(unittest.TestCase):
         self.client.push('ozzy/embryo', 'v4')
         docker_push = self.client.client.push
         docker_push.assert_called_once_with(
-            'ozzy/embryo', tag='v4', insecure_registry=True, stream=True)
+            'ozzy/embryo', tag='v4', insecure_registry=True, decode=True, stream=True)
 
     def test_tag(self, mock_client):
         self.client = DockerClient()


### PR DESCRIPTION
Unauthenticated registry will show:

```
deis pull quay.io/jhansen/example-go-private:latest -a preset-headwind
Creating build... Error:
400 Bad Request
detail: Permission Denied attempting to pull image quay.io/jhansen/example-go-private:latest
```

non-existent one will show 

```
deis pull foo/bar -a preset-headwind
Creating build... Error:
400 Bad Request
detail: image foo/bar:latest not found
```

In the code I only accounted specifically (so far) for the permission denied scenario and the `not found` is a fairly direct passthrough. For some reason the docker registry API is not setting a `code` of 404 or similar when an image is not found.

I could possibly do some `if 'not found' in error:` kind of dealio to include more information but that's not the cleanest.

Fixes #556
Fixes #616

Also #545 would have properly surfaced up in the CLI

Additionally this fixes #619 but with the caveat that we are stuck with a slightly uglier output from the Docker error handling:

```
deis pull dockerhub.com/jhansen/example-go-private -a preset-headwind
Creating build... Error:
400 Bad Request
detail: 500 Server Error: Internal Server Error ("b'unable to ping registry endpoint https://dockerhub.com/v0/\nv2 ping attempt failed with error: Get https://dockerhub.com/v2/: dial tcp 217.70.184.38:443: connection refused\n v1 ping attempt failed with error: Get https://dockerhub.com/v1/_ping: dial tcp 217.70.184.38:443: connection refused'")
```

The whole `b'things are broken'` part is because of how it handles `python-requests` output in py3. Same goes with `\n` - In the future I may go and fix up that in docker-py