### PR TITLE
fix(app): deploy applications on Controller start to create RCs and Pods

### DIFF
--- a/rootfs/api/management/commands/load_db_state_to_k8s.py
+++ b/rootfs/api/management/commands/load_db_state_to_k8s.py
@@ -9,8 +9,8 @@ class Command(BaseCommand):
     to k8s.
     """
     def handle(self, *args, **options):
-        """Publishes Deis platform state from the database to etcd."""
-        print("Publishing DB state to k8s...")
+        """Publishes Deis platform state from the database to kubernetes."""
+        print("Publishing DB state to kubernetes...")
         for model in (Key, App, Domain, Certificate, Config):
             for obj in model.objects.all():
                 obj.save()
@@ -21,4 +21,10 @@ class Command(BaseCommand):
                 domain = get_object_or_404(Domain, domain=domain)
                 cert.attach_in_kubernetes(domain)
 
-        print("Done Publishing DB state to k8s.")
+        # deploy applications
+        print("Deploying available applications")
+        for application in App.objects.all():
+            rel = application.release_set.latest()
+            application.deploy(rel)
+
+        print("Done Publishing DB state to kubernetes.")

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -329,7 +329,7 @@ class App(UuidAuditedModel):
                 log_event(self, err, logging.ERROR)
                 raise
 
-    def deploy(self, user, release):
+    def deploy(self, release):
         """Deploy a new release to this application"""
         if release.build is None:
             raise EnvironmentError('No build associated with this release')

--- a/rootfs/api/models/build.py
+++ b/rootfs/api/models/build.py
@@ -41,7 +41,7 @@ class Build(UuidAuditedModel):
         )
 
         try:
-            self.app.deploy(user, new_release)
+            self.app.deploy(new_release)
             return new_release
         except Exception:
             if 'new_release' in locals():

--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -141,7 +141,7 @@ class Release(UuidAuditedModel):
 
         try:
             if self.build is not None:
-                self.app.deploy(user, new_release)
+                self.app.deploy(new_release)
             return new_release
         except Exception:
             if 'new_release' in locals():

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -304,7 +304,7 @@ class ConfigViewSet(ReleasableViewSet):
         try:
             # It's possible to set config values before a build
             if self.release.build is not None:
-                config.app.deploy(self.request.user, self.release)
+                config.app.deploy(self.release)
         except Exception:
             self.release.delete()
             raise


### PR DESCRIPTION
# Summary of Changes

During Controller start all available applications are deployed with their latest release information. Facilitates proper recovery of an application when pulling information from DB only, on a fresh k8s cluster

# Issue(s) that this PR Closes

Fixes #541

# Testing Instructions

Following test steps can be taken:

```
deis create --no-remote rb
Creating Application... done, created rb
remote available at ssh://git@deis.micro-kube.io:2222/rb.git

deis pull deis/example-go -a rb
Creating build... done
micro-kube  (1.2.2) $ k --namespace=rb get po
NAME              READY     STATUS    RESTARTS   AGE
rb-v2-cmd-2iwb2   1/1       Running   0          11s

k delete ns rb
namespace "rb" deleted

k get po
NAME                          READY     STATUS    RESTARTS   AGE
deis-builder-lp5gf            1/1       Running   1          8m
deis-controller-yq1h3         1/1       Running   0          4m
deis-database-se0kn           1/1       Running   0          8m
deis-logger-64vof             1/1       Running   0          8m
deis-logger-fluentd-5jprr     1/1       Running   0          8m
deis-minio-a64yg              1/1       Running   0          8m
deis-registry-j0axt           1/1       Running   1          8m
deis-router-p5sx1             1/1       Running   0          8m
deis-workflow-manager-trd2i   1/1       Running   0          8m

k delete po deis-controller-yq1h3
pod "deis-controller-yq1h3" deleted
micro-kube  (1.2.2) $ k get ns
NAME          STATUS    AGE
default       Active    10m
deis          Active    9m
kube-system   Active    10m
rb            Active    12s

 k --namespace=rb get po
NAME              READY     STATUS    RESTARTS   AGE
rb-v2-cmd-0yzlm   1/1       Running   0          20s
```