### PR TITLE
ref(release): cleanup old RCs and related kubernetes resources after deploy

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -384,6 +384,9 @@ class App(UuidAuditedModel):
                 log_event(self, err, logging.ERROR)
                 raise
 
+        # cleanup old releases from kubernetes
+        release.cleanup_old()
+
     def _default_structure(self, release):
         """Scale to default structure based on release type"""
         # if there is no SHA, assume a docker image is being promoted


### PR DESCRIPTION
# Summary of Changes

Iterates through all available RCs beside the *latest*, scales them to 0 and deletes. Takes care of the release specific secret as well.
The secret has its own iteration as well in case anything happened on prior runs which made it into an orphan (no RC)

The biggest change here is that the code is not attempting to delete the secret during individual RC deploy but rather as part of the cleanup
after the deploy.

# Issue(s) that this PR Closes

Ref #540

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. do a few releases
4. create an empty RC that uses the same naming scheme as the current one except go a few version in the past
5. run another deis pull
6. verify the hand created RC is gone