### PR TITLE
fix(models): make dates consistent, output Z instead of UTC for ISO8601 compatibility

### DIFF
--- a/rootfs/api/tests/test_certificate.py
+++ b/rootfs/api/tests/test_certificate.py
@@ -95,7 +95,7 @@ class CertificateTest(APITestCase):
 
         expected = {
             'common_name': 'autotest.example.com',
-            'expires': '2016-03-05T17:14:27UTC',
+            'expires': '2016-03-05T17:14:27Z',
             'fingerprint': '37:24:D8:EB:DC:A4:2C:DA:88:55:C5:19:71:D3:9B:43:BA:AC:3A:CE:33:8E:07:52:1C:51:01:A0:97:43:C9:4D',  # noqa
             'san': [],
             'domains': [],

--- a/rootfs/api/tests/test_certificate_use_case_1.py
+++ b/rootfs/api/tests/test_certificate_use_case_1.py
@@ -102,7 +102,7 @@ class CertificateUseCase1Test(APITestCase):
         expected = {
             'name': self.name,
             'common_name': str(self.domain),
-            'expires': '2017-01-14T23:55:59UTC',
+            'expires': '2017-01-14T23:55:59Z',
             'fingerprint': 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6',  # noqa
             'san': [],
             'domains': ['foo.com']

--- a/rootfs/api/tests/test_certificate_use_case_2.py
+++ b/rootfs/api/tests/test_certificate_use_case_2.py
@@ -41,7 +41,7 @@ class CertificateUseCase2Test(APITestCase):
             self.certificates[self.domain]['cert'] = f.read()
 
         # add expires and fingerprints
-        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59UTC'
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
         self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
 
     def tearDown(self):

--- a/rootfs/api/tests/test_certificate_use_case_3.py
+++ b/rootfs/api/tests/test_certificate_use_case_3.py
@@ -43,10 +43,10 @@ class CertificateUseCase3Test(APITestCase):
                 self.certificates[domain]['cert'] = f.read()
 
         # add expires and fingerprints
-        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59UTC'
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
         self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
 
-        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57UTC'
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
         self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
 
     def tearDown(self):

--- a/rootfs/api/tests/test_certificate_use_case_4.py
+++ b/rootfs/api/tests/test_certificate_use_case_4.py
@@ -49,15 +49,15 @@ class CertificateUseCase4Test(APITestCase):
                 self.certificates[domain]['cert'] = f.read()
 
         # add expires, common_name and fingerprints
-        self.certificates['*.foo.com']['expires'] = '2017-01-14T23:59:02UTC'
+        self.certificates['*.foo.com']['expires'] = '2017-01-14T23:59:02Z'
         self.certificates['*.foo.com']['fingerprint'] = '35:FA:8F:58:FF:EA:E0:22:79:29:0B:85:58:73:C2:A5:CD:4A:D9:81:D7:10:9D:4D:03:43:41:E4:1D:92:AB:C5'  # noqa
         self.certificates['*.foo.com']['common_name'] = 'www.foo.com'
 
-        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59UTC'
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
         self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
         self.certificates['foo.com']['common_name'] = 'foo.com'
 
-        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57UTC'
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
         self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
         self.certificates['bar.com']['common_name'] = 'bar.com'
 

--- a/rootfs/api/tests/test_certificate_use_case_5.py
+++ b/rootfs/api/tests/test_certificate_use_case_5.py
@@ -47,12 +47,12 @@ class CertificateUseCase5Test(APITestCase):
                 self.certificates[domain]['cert'] = f.read()
 
         # add expires, common_name and fingerprints
-        self.certificates['*.foo.com']['expires'] = '2017-01-21T21:56:15UTC'
+        self.certificates['*.foo.com']['expires'] = '2017-01-21T21:56:15Z'
         self.certificates['*.foo.com']['fingerprint'] = '8F:8E:5F:F6:7A:78:07:5B:75:3E:10:D5:91:AE:30:4A:48:F4:40:39:90:12:88:B3:41:C6:68:7F:62:F5:CD:EB'  # noqa
         self.certificates['*.foo.com']['common_name'] = '*.foo.com'
         self.certificates['*.foo.com']['san'] = ['foo.com']
 
-        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57UTC'
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
         self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
         self.certificates['bar.com']['common_name'] = 'bar.com'
         self.certificates['bar.com']['san'] = []

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -142,7 +142,7 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # standard datetime format used for logging, model timestamps, etc.
-DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%Z'
+DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 REST_FRAMEWORK = {
     'DATETIME_FORMAT': DEIS_DATETIME_FORMAT,


### PR DESCRIPTION
# Summary of Changes

Changes all output format from using UTC to using Z, which is ISO8601 compatible

# Issue(s) that this PR Closes

Fixes #625 

# Testing Instructions

See #625 for testing steps - Should see Z instead of UTC on started / updated