### PR TITLE
feat(scheduler): allow setting gracefulTerminationPeriod and account for in terminations

### DIFF
--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -268,6 +268,9 @@ SLUGRUNNER_IMAGE = os.environ.get('SLUGRUNNER_IMAGE_NAME', 'quay.io/deisci/slugr
 SLUG_BUILDER_IMAGE_PULL_POLICY = os.environ.get('SLUG_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
 DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
 
+# How long k8s waits for a pod to finish work after a SIGTERM before sending SIGKILL
+KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS = int(os.environ.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', 30))  # noqa
+
 # registry settings
 REGISTRY_HOST = os.environ.get('DEIS_REGISTRY_SERVICE_HOST', '127.0.0.1')
 REGISTRY_PORT = os.environ.get('DEIS_REGISTRY_SERVICE_PORT', 5000)


### PR DESCRIPTION
# Summary of Changes

Allows users to set how long k8s allows pods to stay alive after a SIGTERM before they send SIGKILL - Defaults to 30 (like k8s) but lets users set a lower value for faster deploys if the apps can handle it.

Reduces the pod termination wait to the new setting and uses the existance of "deletionTimestamp" as an indicator if a pod is Terminating, also checks if the pod is past the graceful period and hides it from the pod list via ps:list

# Issue(s) that this PR Closes

Fixes #620
Fixes #621
Fixes #631

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

This change fixes up items marked as pending due to `ps:restart` on a single pod. See #631

# Testing Instructions

This is one slightly hard to test beyond marking the `ps:restart` as not Pending anymore. Most of this code is dealing with Pods that get stuck in Terminating state, see https://github.com/kubernetes/kubernetes/search?q=terminating&type=Issues for the never ending problem that seems to be around in k8s around that