### PR TITLE
feat(registry): add initial support to auth to an external Registry on per app basis

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -105,8 +105,17 @@ class Release(UuidAuditedModel):
 
         # If the build has a SHA, assume it's from deis-builder and in the deis-registry already
         if not self.build.dockerfile and not self.build.sha:
+            # gather custom login information for registry if needed
+            auth = None
+            if self.config.values.get('IMAGE_AUTH_USER', None):
+                auth = {
+                    'username': self.config.values.get('IMAGE_AUTH_USER', None),
+                    'password': self.config.values.get('IMAGE_AUTH_PASSWORD', None),
+                    'email': self.owner.email
+                }
+
             deis_registry = bool(self.build.sha)
-            publish_release(source_image, self.image, deis_registry)
+            publish_release(source_image, self.image, deis_registry, auth)
 
     def previous(self):
         """

--- a/rootfs/registry/tests.py
+++ b/rootfs/registry/tests.py
@@ -5,13 +5,11 @@ Run the tests with "./manage.py test registry"
 """
 
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from django.conf import settings
 from rest_framework.exceptions import PermissionDenied
+from registry import publish_release, RegistryException
 from registry.dockerclient import DockerClient
 
 
@@ -24,23 +22,130 @@ class DockerClientTest(unittest.TestCase):
 
     def test_publish_release(self, mock_client):
         self.client = DockerClient()
-        self.client.publish_release('ozzy/embryo:git-f2a8020', 'ozzy/embryo:v4', True)
+
+        # Make sure login is not called when there are no creds
+        publish_release('ozzy/embryo:git-f2a8020', 'ozzy/embryo:v4', False)
+        self.assertFalse(self.client.client.login.called)
+
+        creds = {
+            'username': 'fake',
+            'password': 'fake',
+            'email': 'fake',
+            'registry': 'quay.io'
+        }
+
+        client = {}
+        client['Status'] = 'Login Succeeded'
+        self.client.client.login.return_value = client
+        publish_release('ozzy/embryo:git-f2a8020', 'ozzy/embryo:v4', False, creds)
+        self.assertTrue(self.client.client.login.called)
         self.assertTrue(self.client.client.pull.called)
         self.assertTrue(self.client.client.tag.called)
         self.assertTrue(self.client.client.push.called)
+
+        publish_release('ozzy/embryo:git-f2a8020', 'ozzy/embryo:v4', True)
+        self.assertTrue(self.client.client.pull.called)
+        self.assertTrue(self.client.client.tag.called)
+        self.assertTrue(self.client.client.push.called)
+
         # Test that a registry host prefix is replaced with deis-registry for the target
-        self.client.publish_release('ozzy/embryo:git-f2a8020', 'quay.io/ozzy/embryo:v4', True)
+        publish_release('ozzy/embryo:git-f2a8020', 'quay.io/ozzy/embryo:v4', True)
         docker_push = self.client.client.push
         docker_push.assert_called_with(
             'localhost:5000/ozzy/embryo', tag='v4', insecure_registry=True,
             decode=True, stream=True)
+
         # Test that blacklisted image names can't be published
         with self.assertRaises(PermissionDenied):
-            self.client.publish_release(
+            publish_release(
                 'deis/controller:v1.11.1', 'deis/controller:v1.11.1', True)
         with self.assertRaises(PermissionDenied):
-            self.client.publish_release(
+            publish_release(
                 'localhost:5000/deis/controller:v1.11.1', 'deis/controller:v1.11.1', True)
+
+    def test_login(self, mock_client):
+        self.client = DockerClient()
+
+        # success
+        client = {}
+        client['Status'] = 'Login Succeeded'
+        self.client.client.login.return_value = client
+
+        creds = {
+            'username': 'fake',
+            'password': 'fake',
+            'email': 'fake',
+            'registry': 'quay.io'
+        }
+        self.client.login('quay.io/deis/foobar', creds)
+        docker_login = self.client.client.login
+        docker_login.assert_called_with(
+            username='fake', password='fake',
+            email='fake', registry='quay.io'
+        )
+
+        # username matches
+        client = {}
+        client['username'] = 'fake'
+        self.client.client.login.return_value = client
+
+        creds = {
+            'username': 'fake',
+            'password': 'fake',
+            'email': 'fake',
+            'registry': 'quay.io'
+        }
+        self.client.login('quay.io/deis/foobar', creds)
+        docker_login = self.client.client.login
+        docker_login.assert_called_with(
+            username='fake', password='fake',
+            email='fake', registry='quay.io'
+        )
+
+    def test_login_failed(self, mock_client):
+        self.client = DockerClient()
+
+        # failed login
+        client = {}
+        client['Status'] = 'Login Failed'
+        self.client.client.login.return_value = client
+
+        creds = {
+            'username': 'fake',
+            'password': 'fake',
+            'email': 'fake',
+            'registry': 'quay.io'
+        }
+
+        with self.assertRaises(PermissionDenied):
+            self.client.login('quay.io/deis/foobar', creds)
+            docker_login = self.client.client.login
+            docker_login.assert_called_with(
+                username='fake', password='fake',
+                email='fake', registry='quay.io'
+            )
+
+    def test_login_bad_creds(self, mock_client):
+        self.client = DockerClient()
+
+        # missing parts of credentials
+        with self.assertRaises(PermissionDenied):
+            creds = {
+                'username': 'fake',
+                'email': 'fake',
+                'registry': 'quay.io'
+            }
+            self.client.login('quay.io/deis/foobar', creds)
+
+        # bad credentials
+        with self.assertRaises(PermissionDenied):
+            creds = {
+                'username': 'fake',
+                'password': 'fake',
+                'email': 'fake',
+                'registry': 'quay.io'
+            }
+            self.client.login('quay.io/deis/foobar', creds)
 
     def test_pull(self, mock_client):
         self.client = DockerClient()
@@ -67,8 +172,15 @@ class DockerClientTest(unittest.TestCase):
         docker_tag = self.client.client.tag
         docker_tag.assert_called_once_with(
             'ozzy/embryo:git-f2a8020', 'ozzy/embryo', tag='v4', force=True)
+
+        # fake failed tag
+        self.client.client.tag.return_value = False
+        with self.assertRaises(RegistryException):
+            self.client.tag('foo/bar:latest', 'foo/bar', 'v1.11.1')
+
         # Test that blacklisted image names can't be tagged
         with self.assertRaises(PermissionDenied):
             self.client.tag('deis/controller:v1.11.1', 'deis/controller', 'v1.11.1')
+
         with self.assertRaises(PermissionDenied):
             self.client.tag('localhost:5000/deis/controller:v1.11.1', 'deis/controller', 'v1.11.1')


### PR DESCRIPTION
## Summary of Changes

This will allow for setting username and password for an external registry to pull images from

`IMAGE_AUTH_USER` and `IMAGE_AUTH_PASSWORD` are support via `config:set` and this is per application.

Currently Docker Hub and Quay are supported and a basic support for long lived tokens under gcr.io - ECR is not supported at this time.

For GCR see https://cloud.google.com/container-registry/docs/auth#using_a_json_key_file
The JSON blob needs to be compacted using `jq -c .` or similar before being set

The UX for this will change, very soon. Doing a separate PR for that


## Issue(s) that this PR Closes

Please list the issue(s) that this PR closes, similar to the below:
ref #639
ref #253 

## Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

Will come when UX has been sorted out

## Associated [Documentation](https://github.com/deis/workflow) PR(s)

Will come when UX has been sorted out

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

https://github.com/deis/workflow/issues/163
https://github.com/deis/controller/issues/639

## Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. Create a Private Repo on Quay.io
4. Set user / pw via `IMAGE_AUTH_USER` and `IMAGE_AUTH_PASSWORD` using `config:set` for the app
5. Do `deis pull` referencing an image in a private repo

Also, please provide a description of the desired result after the tester completes the above steps.

1. The app called "abcd" should be deployed using the private image

## Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: