### PR TITLE
fix(api): pass if no builds are associated with the release

### DIFF
--- a/rootfs/api/management/commands/load_db_state_to_k8s.py
+++ b/rootfs/api/management/commands/load_db_state_to_k8s.py
@@ -24,7 +24,14 @@ class Command(BaseCommand):
         # deploy applications
         print("Deploying available applications")
         for application in App.objects.all():
-            rel = application.release_set.latest()
-            application.deploy(rel)
+            try:
+                rel = application.release_set.latest()
+                application.deploy(rel)
+            except EnvironmentError as e:
+                if str(e) != 'No build associated with this release':
+                    raise
+                print('WARNING: {} has no build associated with '
+                      'its latest release. Skipping deployment...'.format(application))
+                pass
 
         print("Done Publishing DB state to kubernetes.")


### PR DESCRIPTION
# Summary of Changes

If an application only has releases with no builds (such as a `deis create`),
the restoration process will bail out because an exception was raised,
killing the controller. However, this is not a concern if no build
is associated with the release, so we can just check and ignore
this case.

# Issue(s) that this PR Closes

Closes #650 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

None

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

None

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

None

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Cluster with S3 as the backing store
2. Run `deis create`, but don't `deis pull`, `git push`, etc.
3. Destroy the cluster, then create a new one with the same S3 credentials

Results:

1. The controller should be functional.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: