### PR TITLE
ref(scheduler): passthrough k8s state if scheduler does not understand it

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -582,7 +582,7 @@ class App(UuidAuditedModel):
                 if p['metadata']['labels']['type'] == 'run':
                     continue
 
-                state = self._scheduler.resolve_state(p).name
+                state = self._scheduler.resolve_state(p)
 
                 # follows kubelete convention - these are hidden unless show-all is set
                 if state in ['down', 'crashed']:

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -648,13 +648,14 @@ class KubeHTTPClient(object):
             return JobState.destroyed
 
         states = {
-            'Pending': JobState.initialized,
-            'Starting': JobState.starting,
-            'Running': JobState.up,
-            'Terminating': JobState.terminating,
-            'Succeeded': JobState.down,
-            'Failed': JobState.crashed,
-            'Unknown': JobState.error,
+            'Pending': JobState.initializing.name,
+            'ContainerCreating': JobState.creating.name,
+            'Starting': JobState.starting.name,
+            'Running': JobState.up.name,
+            'Terminating': JobState.terminating.name,
+            'Succeeded': JobState.down.name,
+            'Failed': JobState.crashed.name,
+            'Unknown': JobState.error.name,
         }
 
         # being in a running state can mean a pod is starting, actually running or terminating
@@ -667,7 +668,9 @@ class KubeHTTPClient(object):
                 # is the pod ready to serve requests?
                 return states[container_status]
 
-        return states[pod['status']['phase']]
+        # if no match was found for deis mapping then passthrough the real state
+        pod_state = pod['status']['phase']
+        return states.get(pod_state, pod_state)
 
     def _get_port(self, image):
         try:

--- a/rootfs/scheduler/states.py
+++ b/rootfs/scheduler/states.py
@@ -2,8 +2,8 @@ import enum
 
 
 class JobState(enum.Enum):
-    initialized = 1
-    created = 2
+    initializing = 1
+    creating = 2
     starting = 3
     up = 4
     terminating = 5


### PR DESCRIPTION
Reasoning here is that we should be showing people more information when we have not specifically covered the bases instead of potentially more obscure information piece, like "initialized"

Also added ContainerCreating as a state to cover a state we had previously not been using for k8s. It got added in 1.2