### PR TITLE
chore(settings): Allow for comma-delimited RESERVED_NAMES

### DIFF
--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -249,7 +249,7 @@ LOG_LINES = 100
 TEMPDIR = tempfile.mkdtemp(prefix='deis')
 
 # names which apps cannot reserve for routing
-DEIS_RESERVED_NAMES = [os.environ.get('RESERVED_NAMES', 'deis')]
+DEIS_RESERVED_NAMES = os.environ.get('RESERVED_NAMES', '').replace(' ', '').split(',')
 
 # default scheduler settings
 SCHEDULER_MODULE = 'scheduler'


### PR DESCRIPTION
Allow for comma-delimited `RESERVED_NAMES`.

Hard-coded defaults for that env var are also eliminated from the controller itself.  Defaults will be added to the controller's container spec in the chart, thus cluster admins can modify if they choose.

Relates to https://github.com/deis/controller/issues/657