### PR TITLE
feat(deploy): support doing a larger number than 1 in, 1 out deployment

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -341,6 +341,9 @@ class App(UuidAuditedModel):
             self.structure = self._default_structure(release)
             self.save()
 
+        # see if the app config has deploy batch preference, otherwise use global
+        batches = release.config.values.get('DEPLOY_BATCHES', settings.DEPLOY_BATCHES)
+
         # deploy application to k8s. Also handles initial scaling
         deploys = {}
         build_type = app_build_type(release)
@@ -357,7 +360,8 @@ class App(UuidAuditedModel):
                 'build_type': build_type,
                 'healthcheck': release.config.healthcheck(),
                 # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
-                'routable': True if scale_type in ['web', 'cmd'] else False
+                'routable': True if scale_type in ['web', 'cmd'] else False,
+                'batches': batches
             }
 
         # Sort deploys so routable comes first

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -268,6 +268,13 @@ SLUGRUNNER_IMAGE = os.environ.get('SLUGRUNNER_IMAGE_NAME', 'quay.io/deisci/slugr
 SLUG_BUILDER_IMAGE_PULL_POLICY = os.environ.get('SLUG_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
 DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
 
+# Define a global default on how many pods to bring up and then
+# take down sequentially during a deploy
+# Defaults to None, the default is to deploy to as many nodes as
+# the application has been instructed to run on
+# Can also be overwritten on per app basis if desired
+DEPLOY_BATCHES = os.environ.get('DEPLOY_BATCHES', None)
+
 # How long k8s waits for a pod to finish work after a SIGTERM before sending SIGKILL
 KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS = int(os.environ.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', 30))  # noqa
 


### PR DESCRIPTION
## Summary of Changes

By default the deploy system will take the node count the application is deployed on (using tags), but can also look at `DEPLOY_BATCHES` per application and a global Django django setting with the same name.

Example of the default flow is as follows: As a user I have 5 Nodes my application deploys to, the application has a scale of 17, this will lead to the following deploy cadence:
5, 5, 5, 2 (each item represents a in / out), so 5 pods being brought up 3x and then at the end 2 pods

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

e2e will use this by default due to the node count it has

A app specific test is also available at https://github.com/deis/workflow-e2e/pull/184

## Associated [Documentation](https://github.com/deis/workflow) PR(s)

Documentation will come later when we have settled on the env name (may change due to Deployments API, may not)

## Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. One of following needs to be true
  a. Make sure to have more than 1 node
  b. Tell the app it should use `DEPLOY_BATCHES=2`
  b. Configure Controller ENV var `DEPLOY_BATCHES=2`
4. scale to 11
5. Deploy app a few times
6. Look at logs and verify it deploys happened at the step interval defined in `DEPLOY_BATCHES` or the amount of nodes you have
