### PR TITLE
Revert "fix(controller): use django HttpResponse for logs"

### DIFF
--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -99,33 +99,32 @@ class AppTest(APITestCase):
         url = "/v2/apps/{app_id}/logs".format(**locals())
         response = self.client.get(url)
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - 404 from deis-logger
         mock_response.status_code = 404
         response = self.client.get(url)
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - unanticipated status code from deis-logger
         mock_response.status_code = 400
         response = self.client.get(url)
-        self.assertContains(
-            response,
-            "Error accessing logs for {}".format(app_id),
-            status_code=500)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
         mock_response.content = FAKE_LOG_DATA
         response = self.client.get(url)
-        self.assertContains(response, FAKE_LOG_DATA, status_code=200)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, FAKE_LOG_DATA)
 
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url)
-        self.assertContains(
-            response,
-            "Error accessing logs for {}".format(app_id),
-            status_code=500)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
 
         # TODO: test run needs an initial build
 

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -234,20 +234,22 @@ class AppViewSet(BaseDeisViewSet):
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            return HttpResponse(app.logs(request.query_params.get('log_lines',
-                                         str(settings.LOG_LINES))),
-                                status=status.HTTP_200_OK, content_type='text/plain')
+            return Response(app.logs(request.query_params.get('log_lines',
+                                     str(settings.LOG_LINES))),
+                            status=status.HTTP_200_OK, content_type='text/plain')
         except requests.exceptions.RequestException:
-            return HttpResponse("Error accessing logs for {}".format(app.id),
-                                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                                content_type='text/plain')
+            return Response("Error accessing logs for {}".format(app.id),
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            content_type='text/plain')
         except EnvironmentError as e:
             if str(e) == 'Error accessing deis-logger':
-                return HttpResponse("Error accessing logs for {}".format(app.id),
-                                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                                    content_type='text/plain')
+                return Response("Error accessing logs for {}".format(app.id),
+                                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                content_type='text/plain')
             else:
-                return HttpResponse(status=status.HTTP_204_NO_CONTENT)
+                return Response("No logs for {}".format(app.id),
+                                status=status.HTTP_204_NO_CONTENT,
+                                content_type='text/plain')
 
     def run(self, request, **kwargs):
         app = self.get_object()


### PR DESCRIPTION
This is not an easy port over from v1 to v2. The response returned from the controller looks like this now:

```
><> curl -H 'Authorization: token 14c3c00b9f557f14e1ba2912205ef2706a815b1b' http://deis.10.245.1.3.xip.io/v2/apps/go/logs
b'INFO [go]: bacongobbler created initial release\n\nINFO [go]: domain go added\n\nINFO [go]: bacongobbler deployed 779ca3d\n\nINFO [go]: Cleaning up RCS for releases older than v2 (latest)\n\nINFO [go]: Cleaning up orphaned environment var secrets\n\ngo-v2-web-hdk6c -- 2016/04/26 18:14:39 Successfully copied home/go:git-779ca3d7/push/slug.tgz to slug.tgz\n\ngo-v2-web-hdk6c -- 2016/04/26 18:14:39 listening on 5000...\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:16 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:16 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:23 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:24 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:24 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:24 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:24 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:24 10.246.75.1 GET /favicon.ico\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:26 10.246.75.1 GET /\n\ngo-v2-web-hdk6c -- 2016/04/26 18:16:26 10.246.75.1 GET /favicon.ico\n\n'
```

Reverting this change as well as the one in https://github.com/deis/workflow-cli/pull/33 should bring things back to normal.

Reverts deis/controller#592