### PR TITLE
fix(app): catch a higher level python-requests exception for verify application health

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -461,8 +461,9 @@ class App(UuidAuditedModel):
             try:
                 # http://docs.python-requests.org/en/master/user/advanced/#timeouts
                 response = session.get(url, timeout=req_timeout)
-            except requests.exceptions.ConnectTimeout:
-                # We are fine with timeouts, lets keep trying
+            except requests.exceptions.RequestException:
+                # We are fine with timeouts and request problems, lets keep trying
+                time.sleep(1)  # just a bit of a buffer
                 continue
 
             # 30 second timeout (timout per request * 10)


### PR DESCRIPTION
## Summary of Changes

Verify application health via router using a higher level python-requests exception instead of just using `ConnectTimeout`. We don't inherently care if things fail with that request as we are giving the `router` some breathing room to apply Nginx configuration

A user (@dwelch2344) ran into a `ConnectionError` issue:

```
INFO Tagging Docker image deis/example-go:latest as 10.0.135.20:80/test:v2
INFO Pushing Docker image 10.0.135.20:80/test:v2
DEBUG create test
DEBUG create test
DEBUG deploy test-v2-cmd, img test:v2, params {'app_type': 'cmd', 'routable': True, 'version': 'v2', 'healthcheck': {}, 'envs': {}, 'replicas': 1, 'tags': {}, 'cpu': {}, 'build_type': 'deispull', 'memory': {}}, cmd ""
DEBUG No prior RC could be found for test-cmd
DEBUG scaling release test-v2-cmd to 1 out of final 1
DEBUG Not scaling RC test-v2-cmd in Namespace test to 1 replicas. Already at desired replicas
DEBUG scaled up pod number 1 for test-v2-cmd
ERROR test: test-v2-cmd (app::deploy): HTTPConnectionPool(host='10.0.195.149', port=80): Max retries exceeded with url: / (Caused by ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',)))
ERROR [test]: test-v2-cmd (app::deploy): HTTPConnectionPool(host='10.0.195.149', port=80): Max retries exceeded with url: / (Caused by ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',)))
ERROR Internal Server Error: /v2/apps/test/builds/
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 376, in _make_request
    httplib_response = conn.getresponse(buffering=True)
TypeError: getresponse() got an unexpected keyword argument 'buffering'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 559, in urlopen
    body=body, headers=headers)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 378, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib/python3.5/http/client.py", line 1174, in getresponse
    response.begin()
  File "/usr/lib/python3.5/http/client.py", line 282, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.5/http/client.py", line 251, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/requests/adapters.py", line 376, in send
    timeout=timeout
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 629, in urlopen
    release_conn=release_conn, **response_kw)
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py", line 609, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/lib/python3.5/site-packages/requests/packages/urllib3/util/retry.py", line 273, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
requests.packages.urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='10.0.195.149', port=80): Max retries exceeded with url: / (Caused by ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',)))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/lib/python3.5/site-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.5/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/lib/python3.5/site-packages/rest_framework/viewsets.py", line 87, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/lib/python3.5/site-packages/rest_framework/views.py", line 466, in dispatch
    response = self.handle_exception(exc)
  File "/usr/lib/python3.5/site-packages/rest_framework/views.py", line 463, in dispatch
    response = handler(request, *args, **kwargs)
  File "/app/api/views.py", line 177, in create
    return super(AppResourceViewSet, self).create(request, **kwargs)
  File "/app/api/views.py", line 154, in create
    return super(BaseDeisViewSet, self).create(request, *args, **kwargs)
  File "/usr/lib/python3.5/site-packages/rest_framework/mixins.py", line 21, in create
    self.perform_create(serializer)
  File "/app/api/viewsets.py", line 21, in perform_create
    self.post_save(obj)
  File "/app/api/views.py", line 286, in post_save
    self.release = build.create(self.request.user)
  File "/app/api/models/build.py", line 44, in create
    self.app.deploy(user, new_release)
  File "/app/api/models/app.py", line 380, in deploy
    self.verify_application_health(**kwargs)
  File "/app/api/models/app.py", line 454, in verify_application_health
    response = session.get(url, timeout=req_timeout)
  File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 480, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.5/site-packages/requests/adapters.py", line 437, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='10.0.195.149', port=80): Max retries exceeded with url: / (Caused by ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',)))
10.244.1.9 "POST /v2/apps/test/builds/ HTTP/1.1" 500 27 "Deis Client v2.0.0-dev”
```