### PR TITLE
fix(readinessprobe): container shouldn't be restarted if the database is unavailable

### DIFF
--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -26,10 +26,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class HealthCheckView(View):
+class ReadinessCheckView(View):
     """
-    Simple health check view to determine if the server
-    is responding to HTTP requests and DB connection / query.
+    Simple readiness check view to determine DB connection / query.
     """
 
     def get(self, request):
@@ -47,6 +46,17 @@ class HealthCheckView(View):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE
             )
 
+        return HttpResponse("OK")
+    head = get
+
+
+class LivenessCheckView(View):
+    """
+    Simple liveness check view to determine if the server
+    is responding to HTTP requests.
+    """
+
+    def get(self, request):
         return HttpResponse("OK")
     head = get
 

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -7,9 +7,11 @@ installed apps.
 
 
 from django.conf.urls import include, url
-from api.views import HealthCheckView
+from api.views import LivenessCheckView
+from api.views import ReadinessCheckView
 
 urlpatterns = [
-    url(r'^healthz$', HealthCheckView.as_view()),
+    url(r'^healthz$', LivenessCheckView.as_view()),
+    url(r'^readiness$', ReadinessCheckView.as_view()),
     url(r'^v2/', include('api.urls')),
 ]


### PR DESCRIPTION
# Summary of Changes

Currently the controller pod restarts even if the database is not responding as the check is part of the liveness probe.It is enough if the controller just doesn't respond to requests than restarting as restarting is not gone help anything to make database up and hence it should be as part of the readiness probe. 

# Issue(s) that this PR Closes

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app to check the controller is responding
3. stop the database
4. now controller should still be running but not serving requests
5. start the database again and controller should start serving requests.


# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: