### PR TITLE
fix(port): retry a fixed number of times to find the port

### DIFF
--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -7,6 +7,10 @@ from django.conf import settings
 from django.test.runner import DiscoverRunner
 
 
+def mock_port(*args, **kwargs):
+    return 5000
+
+
 # Mock out router requests and add in some jitter
 # Used for application is available in router checks
 def fake_responses(request, context):

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -17,6 +17,7 @@ from api.models import App
 from scheduler import KubeException
 
 from . import adapter
+from . import mock_port
 import requests_mock
 
 
@@ -30,6 +31,7 @@ def _mock_run(*args, **kwargs):
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class AppTest(APITestCase):
     """Tests creation of applications"""
 

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -19,11 +19,13 @@ from registry.dockerclient import RegistryException
 from scheduler import KubeException
 
 from . import adapter
+from . import mock_port
 import requests_mock
 
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class BuildTest(APITransactionTestCase):
 
     """Tests build notification from build system"""

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -15,11 +15,13 @@ from rest_framework.authtoken.models import Token
 from api.models import App, Config
 
 from . import adapter
+from . import mock_port
 import requests_mock
 
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class ConfigTest(APITransactionTestCase):
 
     """Tests setting and updating config values"""

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -11,6 +11,7 @@ from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from . import adapter
+from . import mock_port
 import requests_mock
 
 RSA_PUBKEY = (
@@ -34,6 +35,7 @@ RSA_PUBKEY2 = (
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class HookTest(APITransactionTestCase):
 
     """Tests API hooks used to trigger actions from external components"""

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -18,11 +18,13 @@ from api.models import App, Build, Release
 from scheduler import KubeException
 
 from . import adapter
+from . import mock_port
 import requests_mock
 
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class PodTest(APITransactionTestCase):
     """Tests creation of pods on nodes"""
 

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -17,11 +17,13 @@ from rest_framework.authtoken.models import Token
 from api.models import Release
 from scheduler import KubeHTTPException
 from . import adapter
+from . import mock_port
 import requests_mock
 
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('scheduler.KubeHTTPClient._get_port', mock_port)
 class ReleaseTest(APITransactionTestCase):
 
     """Tests push notification from build system"""

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -16,3 +16,4 @@ PyYAML==3.11
 requests==2.10.0
 requests-toolbelt==0.6.0
 simpleflock==0.0.3
+retrying==1.3.3


### PR DESCRIPTION
# Summary of Changes

retry a fixed number of times to find the port exposed by the docker images as docker-py is flaky and raise an exception if the app is routable but no port is specified.

# Issue(s) that this PR Closes

closes #677 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app and it should properly
3. Deploy an app with no port exposed in the docker file  and no proc file, you should get an error.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom:

