### PR TITLE
fix(config): proc type names validation should allow alphanumeric

### DIFF
--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -11,7 +11,9 @@ from rest_framework import serializers
 
 from api import models
 
-PROCTYPE_MATCH = re.compile(r'^(?P<type>[a-z]+)')
+# proc type name is alphanumeric
+# https://docs-v2.readthedocs.io/en/latest/using-workflow/process-types-and-the-procfile/#declaring-process-types
+PROCTYPE_MATCH = re.compile(r'^(?P<type>[a-z0-9]+)$')
 MEMLIMIT_MATCH = re.compile(r'^(?P<mem>[0-9]+(MB|KB|GB|[BKMG]))$', re.IGNORECASE)
 CPUSHARE_MATCH = re.compile(r'^(?P<cpu>[0-9.]+[m]{0,1})$')
 TAGVAL_MATCH = re.compile(r'^(?:[a-zA-Z\d][-\.\w]{0,61})?[a-zA-Z\d]$')
@@ -145,7 +147,7 @@ class ConfigSerializer(serializers.ModelSerializer):
                 continue
 
             if not re.match(PROCTYPE_MATCH, key):
-                raise serializers.ValidationError("Process types can only contain [a-z]")
+                raise serializers.ValidationError("Process types can only contain alphanumeric")
 
             if not re.match(MEMLIMIT_MATCH, str(value)):
                 raise serializers.ValidationError(
@@ -159,7 +161,7 @@ class ConfigSerializer(serializers.ModelSerializer):
                 continue
 
             if not re.match(PROCTYPE_MATCH, key):
-                raise serializers.ValidationError("Process types can only contain [a-z]")
+                raise serializers.ValidationError("Process types can only contain alphanumeric")
 
             shares = re.match(CPUSHARE_MATCH, str(value))
             if not shares:

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -98,6 +98,9 @@ def delete_pods(url, pods, current, desired):
         if len(removed) == delta:
             break
 
+        if not pods:
+            break
+
         item = pods.pop()
         pod = cache.get(item)
         if 'deletionTimestamp' in pod['metadata']:


### PR DESCRIPTION
## Summary of Changes

And the way the regex was written it would also match as many valid chars as it could find, so even one a-z char at the start was saying the name was valid

https://docs-v2.readthedocs.io/en/latest/using-workflow/process-types-and-the-procfile/#declaring-process-types

## Testing Instructions

Following the test case should be enough

1. Create a Deis Cluster
2. Register an app
3. Create an app that uses a Procfile, use `we&b` as a name for the proc

## Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: