### PR TITLE
ref(models): use DRF APIException as a base for all exceptions

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -11,11 +11,12 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.db import models
-from django.core.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError, NotFound
 from jsonfield import JSONField
 
 from deis import __version__ as deis_version
-from api.models import UuidAuditedModel, log_event, AlreadyExists
+from api.models import UuidAuditedModel, log_event, AlreadyExists, \
+    DeisException, ServiceUnavailable
 
 from api.utils import generate_app_name, app_build_type
 from api.models.release import Release
@@ -43,7 +44,7 @@ def validate_app_structure(value):
         if any(int(v) < 0 for v in value.values()):
             raise ValueError("Must be greater than or equal to zero")
     except ValueError as err:
-        raise ValidationError(err)
+        raise ValidationError(str(err))
 
 
 def validate_reserved_names(value):
@@ -152,7 +153,10 @@ class App(UuidAuditedModel):
             )
 
         # create required minimum resources in k8s for the application
-        self._scheduler.create(self.id)
+        try:
+            self._scheduler.create(self.id)
+        except KubeException as e:
+            raise ServiceUnavailable(str(e)) from e
 
         # Attach the platform specific application sub domain to the k8s service
         # Only attach it on first release in case a customer has remove the app domain
@@ -164,8 +168,8 @@ class App(UuidAuditedModel):
         try:
             # attempt to remove application from kubernetes
             self._scheduler.destroy(self.id)
-        except KubeException:
-            pass
+        except KubeException as e:
+            raise ServiceUnavailable(str(e)) from e
 
         self._clean_app_logs()
         return super(App, self).delete(*args, **kwargs)
@@ -213,7 +217,7 @@ class App(UuidAuditedModel):
             while True:
                 # timed out
                 if elapsed >= timeout:
-                    raise KubeException('timeout - 5 minutes have passed and pods are not up')
+                    raise DeisException('timeout - 5 minutes have passed and pods are not up')
 
                 # restarting a single pod behaves differently, fetch the *newest* pod
                 # and hope it is the right one. Comes back sorted
@@ -234,7 +238,6 @@ class App(UuidAuditedModel):
 
                 elapsed += 5
                 time.sleep(5)
-
         except Exception as e:
             err = "warning, some pods failed to start:\n{}".format(str(e))
             log_event(self, err, logging.WARNING)
@@ -261,9 +264,17 @@ class App(UuidAuditedModel):
         self.create()
 
         if self.release_set.latest().build is None:
-            raise EnvironmentError('No build associated with this release')
+            raise DeisException('No build associated with this release')
 
         release = self.release_set.latest()
+
+        # Validate structure
+        try:
+            for target, count in structure.copy().items():
+                structure[target] = int(count)
+            validate_app_structure(structure)
+        except (TypeError, ValueError) as e:
+            raise DeisException('Invalid scaling format: {}'.format(e))
 
         # test for available process types
         available_process_types = release.build.procfile or {}
@@ -272,7 +283,7 @@ class App(UuidAuditedModel):
                 continue  # allow docker cmd types in case we don't have the image source
 
             if container_type not in available_process_types:
-                raise EnvironmentError(
+                raise DeisException(
                     'Container type {} does not exist in application'.format(container_type))
 
         # merge current structure and the new items together
@@ -323,16 +334,15 @@ class App(UuidAuditedModel):
                     command=command,
                     **kwargs
                 )
-
             except Exception as e:
                 err = '{} (scale): {}'.format(self._get_job_id(scale_type), e)
                 log_event(self, err, logging.ERROR)
-                raise
+                raise ServiceUnavailable(e) from e
 
     def deploy(self, release):
         """Deploy a new release to this application"""
         if release.build is None:
-            raise EnvironmentError('No build associated with this release')
+            raise DeisException('No build associated with this release')
 
         # use create to make sure minimum resources are created
         self.create()
@@ -386,7 +396,7 @@ class App(UuidAuditedModel):
             except Exception as e:
                 err = '{} (app::deploy): {}'.format(self._get_job_id(scale_type), e)
                 log_event(self, err, logging.ERROR)
-                raise
+                raise ServiceUnavailable(err) from e
 
         # cleanup old releases from kubernetes
         release.cleanup_old()
@@ -508,19 +518,20 @@ class App(UuidAuditedModel):
             r = requests.get(url)
         # Handle HTTP request errors
         except requests.exceptions.RequestException as e:
-            logger.error("Error accessing deis-logger using url '{}': {}".format(url, e))
-            raise e
+            msg = "Error accessing deis-logger using url '{}': {}".format(url, e)
+            logger.error(msg)
+            raise ServiceUnavailable(msg) from e
 
         # Handle logs empty or not found
         if r.status_code == 204 or r.status_code == 404:
             logger.info("GET {} returned a {} status code".format(url, r.status_code))
-            raise EnvironmentError('Could not locate logs')
+            raise NotFound('Could not locate logs')
 
         # Handle unanticipated status codes
         if r.status_code != 200:
             logger.error("Error accessing deis-logger: GET {} returned a {} status code"
                          .format(url, r.status_code))
-            raise EnvironmentError('Error accessing deis-logger')
+            raise ServiceUnavailable('Error accessing deis-logger')
 
         # cast content to string since it comes as bytes via the requests object
         return str(r.content)
@@ -532,7 +543,7 @@ class App(UuidAuditedModel):
         """Run a one-off command in an ephemeral app container."""
         release = self.release_set.latest()
         if release.build is None:
-            raise EnvironmentError('No build associated with this release to run this command')
+            raise DeisException('No build associated with this release to run this command')
 
         # TODO: add support for interactive shell
         # SECURITY: shell-escape user input
@@ -576,7 +587,7 @@ class App(UuidAuditedModel):
         except Exception as e:
             err = '{} (run): {}'.format(name, e)
             log_event(self, err, logging.ERROR)
-            raise
+            raise ServiceUnavailable(str(e)) from e
 
     def list_pods(self, *args, **kwargs):
         """Used to list basic information about pods running for a given application"""
@@ -627,7 +638,7 @@ class App(UuidAuditedModel):
         except Exception as e:
             err = '(list pods): {}'.format(e)
             log_event(self, err, logging.ERROR)
-            raise
+            raise ServiceUnavailable(err) from e
 
     def _scheduler_filter(self, **kwargs):
         labels = {'app': self.id}

--- a/rootfs/api/models/build.py
+++ b/rootfs/api/models/build.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db import models
 from jsonfield import JSONField
 
-from api.models import UuidAuditedModel
+from api.models import UuidAuditedModel, DeisException
 
 import logging
 logger = logging.getLogger(__name__)
@@ -43,10 +43,11 @@ class Build(UuidAuditedModel):
         try:
             self.app.deploy(new_release)
             return new_release
-        except Exception:
+        except Exception as e:
             if 'new_release' in locals():
                 new_release.delete()
-            raise
+
+            raise DeisException(str(e)) from e
 
     def save(self, **kwargs):
         try:

--- a/rootfs/api/models/certificate.py
+++ b/rootfs/api/models/certificate.py
@@ -8,13 +8,14 @@ from datetime import datetime
 from django.shortcuts import get_object_or_404
 from django.db import models
 from django.conf import settings
-from django.core.exceptions import ValidationError, SuspiciousOperation
+from django.core.exceptions import SuspiciousOperation
 from django.contrib.postgres.fields import ArrayField
+from rest_framework.exceptions import ValidationError
 
-from api.models import AuditedModel, validate_label, AlreadyExists
+from api.models import AuditedModel, validate_label, AlreadyExists, ServiceUnavailable
 from api.models.domain import Domain
 
-from scheduler import KubeHTTPException
+from scheduler import KubeException
 
 import logging
 logger = logging.getLogger(__name__)
@@ -179,15 +180,15 @@ class Certificate(AuditedModel):
             }
 
             secret = self._scheduler._get_secret(app, name).json()['data']
-        except KubeHTTPException:
+        except KubeException:
             self._scheduler._create_secret(app, name, data)
         else:
             # update cert secret to the TLS Ingress format if required
             if secret != data:
                 try:
                     self._scheduler._update_secret(app, name, data)
-                except KubeHTTPException:
-                    raise
+                except KubeException as e:
+                    raise ServiceUnavailable(str(e)) from e
 
         # get config for the service
         config = self._load_service_config(app, 'router')
@@ -220,9 +221,8 @@ class Certificate(AuditedModel):
                 # We raise an exception when a secret doesn't exist
                 self._scheduler._get_secret(app, name)
                 self._scheduler._delete_secret(app, name)
-            except KubeHTTPException as e:
-                logger.critical(e)
-                raise EnvironmentError("Could not delete certificate secret {} for application {}".format(name, app))  # noqa
+            except KubeException as e:
+                raise ServiceUnavailable("Could not delete certificate secret {} for application {}".format(name, app)) from e  # noqa
 
         # get config for the service
         config = self._load_service_config(app, 'router')

--- a/rootfs/api/models/config.py
+++ b/rootfs/api/models/config.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db import models
 from jsonfield import JSONField
 
-from api.models import UuidAuditedModel
+from api.models import UuidAuditedModel, DeisException
 
 
 class Config(UuidAuditedModel):
@@ -107,7 +107,7 @@ class Config(UuidAuditedModel):
             new = set(labels) - set(old)
             message += ' - Addition of {} is the cause'.format(', '.join(new))
 
-        raise EnvironmentError(message)
+        raise DeisException(message)
 
     def save(self, **kwargs):
         """merge the old config with the new"""

--- a/rootfs/api/models/key.py
+++ b/rootfs/api/models/key.py
@@ -2,7 +2,7 @@ import base64
 
 from django.conf import settings
 from django.db import models
-from django.core.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError
 
 from api.models import UuidAuditedModel
 from api.utils import fingerprint
@@ -13,7 +13,7 @@ def validate_base64(value):
     try:
         base64.b64decode(value.split()[1])
     except Exception as e:
-        raise ValidationError(e)
+        raise ValidationError(str(e))
 
 
 class Key(UuidAuditedModel):

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -248,7 +248,7 @@ class AuthTest(APITestCase):
         }
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(token))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data, {'detail': 'Current password does not match'})
         self.assertEqual(response.get('content-type'), 'application/json')
         submit = {

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -3,24 +3,21 @@ RESTful view classes for presenting Deis API objects.
 """
 from django.http import Http404, HttpResponse
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from guardian.shortcuts import assign_perm, get_objects_for_user, \
     get_users_with_perms, remove_perm
 from django.views.generic import View
 from rest_framework import mixins, renderers, status
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, NotFound, AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.authtoken.models import Token
 
 from api import authentication, models, permissions, serializers, viewsets
-from api.models import AlreadyExists
-from scheduler import KubeException
+from api.models import AlreadyExists, ServiceUnavailable, DeisException
 
-import requests
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,10 +38,7 @@ class ReadinessCheckView(View):
             # FIXME why is turning on DEBUG=true in env not outputting this error?
             logger.debug(str(e))
 
-            return HttpResponse(
-                "Database health check failed",
-                status=status.HTTP_503_SERVICE_UNAVAILABLE
-            )
+            raise ServiceUnavailable("Database health check failed")
 
         return HttpResponse("OK")
     head = get
@@ -92,7 +86,7 @@ class UserManagementViewSet(GenericViewSet):
         # A user can not be removed without apps changing ownership first
         if len(models.App.objects.filter(owner=target_obj)) > 0:
             msg = '{} still has applications assigned. Delete or transfer ownership'.format(str(target_obj))  # noqa
-            return Response({'detail': msg}, status=status.HTTP_409_CONFLICT)
+            raise AlreadyExists(msg)
 
         target_obj.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -106,10 +100,11 @@ class UserManagementViewSet(GenericViewSet):
                 target_obj = get_object_or_404(User, username=request.data['username'])
             else:
                 raise PermissionDenied()
+
         if request.data.get('password') or not caller_obj.is_superuser:
             if not target_obj.check_password(request.data['password']):
-                return Response({'detail': 'Current password does not match'},
-                                status=status.HTTP_400_BAD_REQUEST)
+                raise AuthenticationFailed('Current password does not match')
+
         target_obj.set_password(request.data['new_password'])
         target_obj.save()
         return Response({'status': 'password set'})
@@ -158,17 +153,6 @@ class BaseDeisViewSet(viewsets.OwnerViewSet):
     lookup_field = 'id'
     permission_classes = [IsAuthenticated, permissions.IsAppUser]
     renderer_classes = [renderers.JSONRenderer]
-
-    def create(self, request, *args, **kwargs):
-        try:
-            return super(BaseDeisViewSet, self).create(request, *args, **kwargs)
-        except AlreadyExists as e:
-            return Response({'detail': str(e)}, status=status.HTTP_409_CONFLICT)
-        except EnvironmentError as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        # If the scheduler oopsie'd
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
 
 class AppResourceViewSet(BaseDeisViewSet):
@@ -221,52 +205,28 @@ class AppViewSet(BaseDeisViewSet):
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(instance, many=True)
-
         return Response(serializer.data)
 
     def scale(self, request, **kwargs):
-        new_structure = {}
-        app = self.get_object()
-        try:
-            for target, count in request.data.items():
-                new_structure[target] = int(count)
-            models.validate_app_structure(new_structure)
-            app.scale(request.user, new_structure)
-        except (TypeError, ValueError) as e:
-            return Response({'detail': 'Invalid scaling format: {}'.format(e)},
-                            status=status.HTTP_400_BAD_REQUEST)
-        except (EnvironmentError, ValidationError) as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.get_object().scale(request.user, request.data)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            return HttpResponse(app.logs(request.query_params.get('log_lines',
-                                         str(settings.LOG_LINES))),
-                                status=status.HTTP_200_OK, content_type='text/plain')
-        except requests.exceptions.RequestException:
+            logs = app.logs(request.query_params.get('log_lines', str(settings.LOG_LINES)))
+            return HttpResponse(logs, status=status.HTTP_200_OK, content_type='text/plain')
+        except NotFound:
+            return HttpResponse(status=status.HTTP_204_NO_CONTENT)
+        except ServiceUnavailable:
+            # TODO make 503
             return HttpResponse("Error accessing logs for {}".format(app.id),
                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                                 content_type='text/plain')
-        except EnvironmentError as e:
-            if str(e) == 'Error accessing deis-logger':
-                return HttpResponse("Error accessing logs for {}".format(app.id),
-                                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                                    content_type='text/plain')
-            else:
-                return HttpResponse(status=status.HTTP_204_NO_CONTENT)
 
     def run(self, request, **kwargs):
         app = self.get_object()
-        try:
-            rc, output = app.run(self.request.user, request.data['command'])
-        except EnvironmentError as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        rc, output = app.run(self.request.user, request.data['command'])
         return Response({'rc': rc, 'output': str(output)})
 
     def update(self, request, **kwargs):
@@ -303,9 +263,9 @@ class ConfigViewSet(ReleasableViewSet):
             # It's possible to set config values before a build
             if self.release.build is not None:
                 config.app.deploy(self.release)
-        except Exception:
+        except Exception as e:
             self.release.delete()
-            raise
+            raise DeisException(str(e))
 
 
 class PodViewSet(AppResourceViewSet):
@@ -313,29 +273,19 @@ class PodViewSet(AppResourceViewSet):
     serializer_class = serializers.PodSerializer
 
     def list(self, *args, **kwargs):
-        app = self.get_app()
-
-        try:
-            pods = app.list_pods(*args, **kwargs)
-            data = self.get_serializer(pods, many=True).data
-            # fake out pagination for now
-            pagination = {'results': data, 'count': len(data)}
-            return Response(pagination, status=status.HTTP_200_OK)
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        pods = self.get_app().list_pods(*args, **kwargs)
+        data = self.get_serializer(pods, many=True).data
+        # fake out pagination for now
+        pagination = {'results': data, 'count': len(data)}
+        return Response(pagination, status=status.HTTP_200_OK)
 
     def restart(self, *args, **kwargs):
-        app = self.get_app()
-
-        try:
-            pods = app.restart(**kwargs)
-            data = self.get_serializer(pods, many=True).data
-            # fake out pagination for now
-            # pagination = {'results': data, 'count': len(data)}
-            pagination = data
-            return Response(pagination, status=status.HTTP_200_OK)
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        pods = self.get_app().restart(**kwargs)
+        data = self.get_serializer(pods, many=True).data
+        # fake out pagination for now
+        # pagination = {'results': data, 'count': len(data)}
+        pagination = data
+        return Response(pagination, status=status.HTTP_200_OK)
 
 
 class DomainViewSet(AppResourceViewSet):
@@ -365,10 +315,6 @@ class CertificateViewSet(BaseDeisViewSet):
             self.get_object().attach(*args, **kwargs)
         except Http404:
             raise
-        except AlreadyExists as e:
-            return Response({'detail': str(e)}, status=status.HTTP_409_CONFLICT)
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         return Response(status=status.HTTP_201_CREATED)
 
@@ -377,8 +323,6 @@ class CertificateViewSet(BaseDeisViewSet):
             self.get_object().detach(*args, **kwargs)
         except Http404:
             raise
-        except KubeException as e:
-            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -405,21 +349,10 @@ class ReleaseViewSet(AppResourceViewSet):
         Create a new release as a copy of the state of the compiled slug and config vars of a
         previous release.
         """
-        app = self.get_app()
-        try:
-            release = app.release_set.latest()
-            version_to_rollback_to = release.version - 1
-            if request.data.get('version'):
-                version_to_rollback_to = int(request.data['version'])
-            new_release = release.rollback(request.user, version_to_rollback_to)
-            response = {'version': new_release.version}
-            return Response(response, status=status.HTTP_201_CREATED)
-        except EnvironmentError as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        except Exception:
-            if 'new_release' in locals():
-                new_release.delete()
-            raise
+        release = self.get_app().release_set.latest()
+        new_release = release.rollback(request.user, request.data.get('version', None))
+        response = {'version': new_release.version}
+        return Response(response, status=status.HTTP_201_CREATED)
 
 
 class BaseHookViewSet(BaseDeisViewSet):
@@ -487,7 +420,7 @@ class KeyHookViewSet(BaseHookViewSet):
                      .values('public', 'fingerprint') \
                      .order_by('created')
         if not keys:
-            raise Http404("No Keys match the given query.")
+            raise NotFound("No Keys match the given query.")
 
         for info in keys:
             data[request.user.username].append({


### PR DESCRIPTION
## Summary of Changes

Move to using `DeisException` that extends `APIException` (with 400 as a status code) instead of `EnvironmentError`, have `AlreadyExists` extend `APIException` with 409 and `KubeException` and Logger related exceptions get raised up to the view as `ServiceUnavailable`

Additionally using `from e` when re-raising exception to keep contextual information if that is ever required (https://www.python.org/dev/peps/pep-3134/)

https://github.com/tomchristie/django-rest-framework/blob/master/docs/api-guide/exceptions.md has further info on DRF exceptions

## Issue(s) that this PR Closes

ref #612