### PR TITLE
feat(scheduler): add 10 mins to deploy timeout if image pull is slow

### DIFF
--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -250,7 +250,7 @@ def fetch_all(request, context):
 
 
 def prepare_query_filters(query):
-    filters = {'labels': {}}
+    filters = {'labels': {}, 'fields': {}}
     if query:
         queries = parse_qs(query)
         if 'labelSelector' in queries:
@@ -258,6 +258,12 @@ def prepare_query_filters(query):
                 for item in items.split(','):
                     key, value = item.split('=')
                     filters['labels'][key] = value
+
+        if 'fieldSelector' in queries:
+            for items in queries['fieldSelector']:
+                for item in items.split(','):
+                    key, value = item.split('=')
+                    filters['fields'][key] = value
 
     return filters
 
@@ -344,6 +350,8 @@ def put(request, context):
 
     if resource_type == 'replicationcontrollers':
         data['metadata']['resourceVersion'] += 1
+        data['metadata']['generation'] += 1
+        data['status']['observedGeneration'] += 1
         upsert_pods(data, url)
 
     # Update the individual resource


### PR DESCRIPTION
## Summary of Changes

After a minute of pulling the image (considered pretty high) then additionl 10 minutes are added on top.
This will help when the cache is cold. Slugrunner and generally big images are being used (1GB or higher generally)

## Issue(s) that this PR Closes

Fixes #459

## Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

No e2e for this as it would slow down e2e a lot. From time to time e2e will hit this tho if GKE is being slow

## Testing Instructions

This is a hard one to test due to the need for a big image

1. Create a Deis Cluster
2. Register an app
3. Run `docker rmi $(docker images -q quay.io/deisci/slugrunner)` against the k8s master
4. Run `make deploy` with this branch
5. `git push` an app

Alternative is to modify the code (locally) and doing a local git commit to Controller itself (for `make deploy`) and changing `seconds = 60` to `seconds = 2` in `scheduler/__init__.py` 

Also, please provide a description of the desired result after the tester completes the above steps.

1. The app called "abcd" should be deployed
2. Monitor the controller logs for `Kubernetes has been pulling the image for 60 seconds`