### PR TITLE
fix(scheduler): use CA cert to verify API SSL certficiate

### DIFF
--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -254,6 +254,8 @@ DEIS_RESERVED_NAMES = os.environ.get('RESERVED_NAMES', '').replace(' ', '').spli
 # default scheduler settings
 SCHEDULER_MODULE = 'scheduler'
 SCHEDULER_URL = "https://{}:{}".format(
+    # accessing the k8s api server by IP address rather than hostname avoids
+    # intermittent DNS errors
     os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default.svc.cluster.local'),
     os.environ.get('KUBERNETES_SERVICE_PORT', '443')
 )

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -337,11 +337,7 @@ class KubeHTTPClient(object):
             'Content-Type': 'application/json',
             'User-Agent': user_agent('Deis Controller', deis_version)
         }
-        # TODO: accessing the k8s api server by IP address rather than hostname avoids
-        # TODO look at https://toolbelt.readthedocs.org/en/latest/adapters.html#fingerprintadapter
-        # intermittent DNS errors, but at the price of disabling cert verification.
-        # session.verify = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-        session.verify = False
+        session.verify = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
         self.session = session
 
     def deploy(self, namespace, name, image, command, **kwargs):  # noqa


### PR DESCRIPTION
In all tests the CA issue seems to be gone and it can handle the IP.

Alternatively I tried out https://toolbelt.readthedocs.org/en/latest/adapters.html#fingerprintadapter but that proofed a little annoying since the fingerprints never stayed consistent for whatever reason