### PR TITLE
feat(images): use imagePullSecret when pulling a private image

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -338,7 +338,8 @@ class App(UuidAuditedModel):
                 'memory': release.config.memory,
                 'cpu': release.config.cpu,
                 'tags': release.config.tags,
-                'envs': envs,
+                'envs': release.config.values,
+                'registry': release.config.registry,
                 'version': "v{}".format(release.version),
                 'replicas': replicas,
                 'app_type': scale_type,
@@ -390,7 +391,8 @@ class App(UuidAuditedModel):
                 'memory': release.config.memory,
                 'cpu': release.config.cpu,
                 'tags': release.config.tags,
-                'envs': envs,
+                'envs': release.config.values,
+                'registry': release.config.registry,
                 # only used if there is no previous RC
                 'replicas': replicas,
                 'version': "v{}".format(release.version),
@@ -583,6 +585,7 @@ class App(UuidAuditedModel):
             'cpu': release.config.cpu,
             'tags': release.config.tags,
             'envs': release.config.values,
+            'registry': release.config.registry,
             'version': "v{}".format(release.version),
             'build_type': release.build.type,
         }

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -333,12 +333,11 @@ class App(UuidAuditedModel):
             # fetch application port and inject into ENV Vars as needed
             envs['PORT'] = release.get_port(routable)
 
-            image = release.image
             kwargs = {
                 'memory': release.config.memory,
                 'cpu': release.config.cpu,
                 'tags': release.config.tags,
-                'envs': release.config.values,
+                'envs': envs,
                 'registry': release.config.registry,
                 'version': "v{}".format(release.version),
                 'replicas': replicas,
@@ -353,7 +352,7 @@ class App(UuidAuditedModel):
                 self._scheduler.scale(
                     namespace=self.id,
                     name=self._get_job_id(scale_type),
-                    image=image,
+                    image=release.image,
                     command=command,
                     **kwargs
                 )
@@ -384,14 +383,14 @@ class App(UuidAuditedModel):
             # only web / cmd are routable
             # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
             routable = True if scale_type in ['web', 'cmd'] else False
-            # fetch application port and inject into ENV Vars as needed
+            # fetch application port and inject into ENV vars as needed
             envs['PORT'] = release.get_port(routable)
 
             deploys[scale_type] = {
                 'memory': release.config.memory,
                 'cpu': release.config.cpu,
                 'tags': release.config.tags,
-                'envs': release.config.values,
+                'envs': envs,
                 'registry': release.config.registry,
                 # only used if there is no previous RC
                 'replicas': replicas,

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -31,7 +31,7 @@ def _mock_run(*args, **kwargs):
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class AppTest(APITestCase):
     """Tests creation of applications"""
 

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -25,7 +25,7 @@ import requests_mock
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class BuildTest(APITransactionTestCase):
 
     """Tests build notification from build system"""

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -21,7 +21,7 @@ import requests_mock
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class ConfigTest(APITransactionTestCase):
 
     """Tests setting and updating config values"""

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -35,7 +35,7 @@ RSA_PUBKEY2 = (
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class HookTest(APITransactionTestCase):
 
     """Tests API hooks used to trigger actions from external components"""

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -24,7 +24,7 @@ import requests_mock
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class PodTest(APITransactionTestCase):
     """Tests creation of pods on nodes"""
 

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -23,7 +23,7 @@ import requests_mock
 
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
-@mock.patch('api.models.release.Release.get_port', mock_port)
+@mock.patch('api.models.release.docker_get_port', mock_port)
 class ReleaseTest(APITransactionTestCase):
 
     """Tests push notification from build system"""

--- a/rootfs/registry/__init__.py
+++ b/rootfs/registry/__init__.py
@@ -1,1 +1,1 @@
-from .dockerclient import publish_release, RegistryException  # noqa
+from .dockerclient import publish_release, get_port, RegistryException  # noqa


### PR DESCRIPTION
use a k8s Secret to encode a `.docker/config.json` to completely bypass the Controller when it comes to images if a private registry is being used

Handles the various possible errors coming from k8s and bubble that up through to the end user, similar to how the deis dockerclient can do.
k8s adds more information on top of what docker gives so an error message bubbled up from this compared to when the Controller was handling the Docker interaction

ref #639