### PR TITLE
chore(tests): output the content/data of the response when status code does not match

### DIFF
--- a/rootfs/api/tests/test_api_middleware.py
+++ b/rootfs/api/tests/test_api_middleware.py
@@ -30,7 +30,7 @@ class APIMiddlewareTest(APITestCase):
             '/v2/apps',
             HTTP_DEIS_VERSION=__version__.rsplit('.', 2)[0]
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.has_header('DEIS_API_VERSION'), True)
         self.assertEqual(response['DEIS_API_VERSION'], __version__.rsplit('.', 1)[0])
 
@@ -42,11 +42,11 @@ class APIMiddlewareTest(APITestCase):
             '/v2/apps',
             HTTP_DEIS_VERSION='1234.5678'
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_deis_version_header_not_present(self):
         """
         Test that when the version header is not present, the request is accepted.
         """
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -43,7 +43,7 @@ class AuthTest(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         for key in response.data:
             self.assertIn(key, ['id', 'last_login', 'is_superuser', 'username', 'first_name',
                                 'last_name', 'email', 'is_active', 'is_superuser', 'is_staff',
@@ -117,7 +117,7 @@ class AuthTest(APITestCase):
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         for key in response.data:
             self.assertIn(key, ['id', 'last_login', 'is_superuser', 'username', 'first_name',
                                 'last_name', 'email', 'is_active', 'is_superuser', 'is_staff',
@@ -183,18 +183,18 @@ class AuthTest(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # cancel the account
         url = '/v2/auth/cancel'
         user = User.objects.get(username=username)
         token = Token.objects.get(user=user).key
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(token))
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = '/v2/auth/register'
         response = self.client.post(url, other_submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # normal user can't delete another user
         url = '/v2/auth/cancel'
@@ -207,14 +207,14 @@ class AuthTest(APITestCase):
         # admin can delete another user
         response = self.client.delete(url, {'username': other_username},
                                       HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # user can not be deleted if it has an app attached to it
         response = self.client.post(
             '/v2/apps',
             HTTP_AUTHORIZATION='token {}'.format(self.admin_token)
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']  # noqa
         self.assertIn('id', response.data)
 
@@ -237,7 +237,7 @@ class AuthTest(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         # change password
         url = '/v2/auth/passwd'
         user = User.objects.get(username=username)
@@ -248,7 +248,7 @@ class AuthTest(APITestCase):
         }
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(token))
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 401, response.data)
         self.assertEqual(response.data, {'detail': 'Current password does not match'})
         self.assertEqual(response.get('content-type'), 'application/json')
         submit = {
@@ -257,7 +257,7 @@ class AuthTest(APITestCase):
         }
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # test login with old password
         response = self.client.login(username=username, password=password)
@@ -281,7 +281,7 @@ class AuthTest(APITestCase):
         }
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # test login with old password
         response = self.client.login(username=self.user1.username, password=old_password)
@@ -301,7 +301,7 @@ class AuthTest(APITestCase):
         # change back password with a regular user
         response = self.client.post(url, submit,
                                     HTTP_AUTHORIZATION='token {}'.format(self.user1_token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # test login with new password
         response = self.client.login(username=self.user1.username, password=old_password)
@@ -313,18 +313,18 @@ class AuthTest(APITestCase):
 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token)
         response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertNotEqual(response.data['token'], self.admin_token)
 
         self.admin_token = Token.objects.get(user=self.admin).key
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token)
 
         response = self.client.post(url, {"username": "autotest2"})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertNotEqual(response.data['token'], self.user1_token)
 
         response = self.client.post(url, {"all": "true"})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 401, response.data)

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -47,41 +47,41 @@ class BuildTest(APITransactionTestCase):
         """
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         # check to see that no initial build was created
         url = "/v2/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.data['count'], 0)
         # post a new build
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         build_id = str(response.data['uuid'])
         build1 = response.data
         self.assertEqual(response.data['image'], body['image'])
         # read the build
         url = "/v2/apps/{app_id}/builds/{build_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         build2 = response.data
         self.assertEqual(build1, build2)
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         build3 = response.data
         self.assertEqual(response.data['image'], body['image'])
         self.assertNotEqual(build2['uuid'], build3['uuid'])
         # disallow put/patch/delete
         response = self.client.put(url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_response_data(self, mock_requests):
         """Test that the serialized response contains only relevant data."""
@@ -109,17 +109,17 @@ class BuildTest(APITransactionTestCase):
     def test_build_default_containers(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         # post an image as a build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
         self.assertEqual(container['type'], 'cmd')
@@ -130,7 +130,7 @@ class BuildTest(APITransactionTestCase):
         # start with a new app
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         # post a new build with procfile
         url = "/v2/apps/{app_id}/builds".format(**locals())
@@ -140,11 +140,11 @@ class BuildTest(APITransactionTestCase):
             'dockerfile': "FROM scratch"
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
         self.assertEqual(container['type'], 'cmd')
@@ -155,7 +155,7 @@ class BuildTest(APITransactionTestCase):
         # start with a new app
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build with procfile
@@ -169,11 +169,11 @@ class BuildTest(APITransactionTestCase):
             }
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
         self.assertEqual(container['type'], 'cmd')
@@ -184,7 +184,7 @@ class BuildTest(APITransactionTestCase):
         # start with a new app
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         # post a new build with procfile
 
@@ -198,11 +198,11 @@ class BuildTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         container = response.data['results'][0]
         self.assertEqual(container['type'], 'web')
@@ -214,13 +214,13 @@ class BuildTest(APITransactionTestCase):
         """Test the text representation of a build."""
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         # post a new build
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         build = Build.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(build), "{}-{}".format(
                          response.data['app'], str(response.data['uuid'])[:7]))
@@ -236,7 +236,7 @@ class BuildTest(APITransactionTestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build as admin
@@ -244,7 +244,7 @@ class BuildTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         build = Build.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(build), "{}-{}".format(
@@ -277,7 +277,7 @@ class BuildTest(APITransactionTestCase):
         """
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -291,18 +291,18 @@ class BuildTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
 
         # scale to zero
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # post another build
         url = "/v2/apps/{app_id}/builds".format(**locals())
@@ -315,10 +315,10 @@ class BuildTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
     def test_build_image_in_registry(self, mock_requests):
@@ -332,7 +332,7 @@ class BuildTest(APITransactionTestCase):
         image = '{}/autotest/example'.format(settings.REGISTRY_HOST)
         body = {'image': image}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         build = Build.objects.get(uuid=response.data['uuid'])
         release = build.app.release_set.latest()
@@ -344,7 +344,7 @@ class BuildTest(APITransactionTestCase):
         image = '{}/autotest/example'.format(settings.REGISTRY_URL)
         body = {'image': image}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         build = Build.objects.get(uuid=response.data['uuid'])
         release = build.app.release_set.latest()
@@ -359,13 +359,13 @@ class BuildTest(APITransactionTestCase):
         url = "/v2/apps/test/builds"
         image = 'autotest/example'
         response = self.client.post(url, {'image': image})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # set some registry information
         url = '/v2/apps/test/config'
         body = {'registry': json.dumps({'username': 'bob', 'password': 'zoomzoom'})}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_release_create_failure(self, mock_requests):
         """
@@ -378,7 +378,7 @@ class BuildTest(APITransactionTestCase):
         url = "/v2/apps/test/builds"
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['image'], body['image'])
 
         with mock.patch('api.models.App.deploy') as mock_deploy:
@@ -387,7 +387,7 @@ class BuildTest(APITransactionTestCase):
             url = "/v2/apps/test/builds"
             body = {'image': 'autotest/example'}
             response = self.client.post(url, body)
-            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 400, response.data)
 
     def test_release_registry_create_failure(self, mock_requests):
         """
@@ -400,7 +400,7 @@ class BuildTest(APITransactionTestCase):
         url = "/v2/apps/test/builds"
         body = {'image': 'autotest/example'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['image'], body['image'])
 
         with mock.patch('api.models.Release.publish') as mock_registry:
@@ -409,7 +409,7 @@ class BuildTest(APITransactionTestCase):
             url = "/v2/apps/test/builds"
             body = {'image': 'autotest/example'}
             response = self.client.post(url, body)
-            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 400, response.data)
 
     def test_build_deploy_kube_failure(self, mock_requests):
         """
@@ -424,4 +424,4 @@ class BuildTest(APITransactionTestCase):
             url = "/v2/apps/test/builds"
             body = {'image': 'autotest/example'}
             response = self.client.post(url, body)
-            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 400, response.data)

--- a/rootfs/api/tests/test_certificate.py
+++ b/rootfs/api/tests/test_certificate.py
@@ -45,7 +45,7 @@ class CertificateTest(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_update_certificate(self):
         """Tests update of a certificate."""
@@ -57,7 +57,7 @@ class CertificateTest(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_create_certificate_with_different_common_name(self):
         """
@@ -72,7 +72,7 @@ class CertificateTest(APITestCase):
                 'common_name': 'foo.example.com'
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['common_name'], 'autotest.example.com')
 
     def test_get_certificate_screens_data(self):
@@ -88,10 +88,10 @@ class CertificateTest(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         response = self.client.get('{}/{}'.format(self.url, 'random-test-cert'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         expected = {
             'common_name': 'autotest.example.com',
@@ -106,9 +106,9 @@ class CertificateTest(APITestCase):
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -120,7 +120,7 @@ class CertificateTest(APITestCase):
         )
         url = '/v2/certs/random-test-cert'
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
     def test_create_invalid_cert(self):
         """Upload a cert that can't be loaded by pyopenssl"""
@@ -132,7 +132,7 @@ class CertificateTest(APITestCase):
                 'key': 'i am bad data as well'
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         # match partial since right now the rest is pyopenssl errors
         self.assertIn('Could not load certificate', response.data['certificate'][0])
 

--- a/rootfs/api/tests/test_certificate_use_case_1.py
+++ b/rootfs/api/tests/test_certificate_use_case_1.py
@@ -48,7 +48,7 @@ class CertificateUseCase1Test(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_create_certificate_with_different_common_name(self):
         """
@@ -63,7 +63,7 @@ class CertificateUseCase1Test(APITestCase):
                 'common_name': 'foo.example.com'
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['common_name'], 'foo.com')
 
     def test_get_certificate_screens_data(self):
@@ -79,7 +79,7 @@ class CertificateUseCase1Test(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Attach to domain that does not exist
         response = self.client.post(
@@ -93,11 +93,11 @@ class CertificateUseCase1Test(APITestCase):
             '{}/{}/domain/'.format(self.url, self.name),
             {'domain': str(self.domain)}
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Assert data
         response = self.client.get('{}/{}'.format(self.url, self.name))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         expected = {
             'name': self.name,
@@ -114,7 +114,7 @@ class CertificateUseCase1Test(APITestCase):
         response = self.client.delete(
             '{}/{}/domain/{}'.format(self.url, self.name, self.domain)
         )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # detach a domain that does not exist from a certificate
         response = self.client.delete(
@@ -124,15 +124,15 @@ class CertificateUseCase1Test(APITestCase):
 
         # Assert data
         response = self.client.get('{}/{}'.format(self.url, self.name))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -144,7 +144,7 @@ class CertificateUseCase1Test(APITestCase):
 
         url = '/v2/certs/{}'.format(self.name)
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
     def test_delete_certificate_with_attached_domain(self):
         """
@@ -160,18 +160,18 @@ class CertificateUseCase1Test(APITestCase):
                 'key': self.key
             }
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Attach domain to certificate
         response = self.client.post(
             '{}/{}/domain/'.format(self.url, self.name),
             {'domain': str(self.domain)}
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Assert data from cert side
         response = self.client.get('{}/{}'.format(self.url, self.name))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.data['domains'], [str(self.domain)])
 
         # Assert data from domain side
@@ -181,7 +181,7 @@ class CertificateUseCase1Test(APITestCase):
         # Delete certificate
         url = '/v2/certs/{}'.format(self.name)
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # verify certificate is not attached to domain anymore
         domain = Domain.objects.get(id=self.domain.id)

--- a/rootfs/api/tests/test_certificate_use_case_2.py
+++ b/rootfs/api/tests/test_certificate_use_case_2.py
@@ -59,7 +59,7 @@ class CertificateUseCase2Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
     def test_get_certificate_screens_data(self):
         """
@@ -76,20 +76,20 @@ class CertificateUseCase2Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
                 {'domain': domain}
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Assert data
             response = self.client.get(
                 '{}/{}'.format(self.url, certificate['name'])
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
 
             expected = {
                 'name': certificate['name'],
@@ -110,19 +110,19 @@ class CertificateUseCase2Test(APITestCase):
             response = self.client.delete(
                 '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)
 
             # Assert data
             response = self.client.get('{}/{}'.format(self.url, certificate['name']))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -135,4 +135,4 @@ class CertificateUseCase2Test(APITestCase):
             )
             url = '/v2/certs/{}'.format(certificate['name'])
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/test_certificate_use_case_3.py
+++ b/rootfs/api/tests/test_certificate_use_case_3.py
@@ -64,7 +64,7 @@ class CertificateUseCase3Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
     def test_get_certificate_screens_data(self):
         """
@@ -81,18 +81,18 @@ class CertificateUseCase3Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
                 {'domain': domain}
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Assert data
             response = self.client.get('{}/{}'.format(self.url, certificate['name']))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
 
             expected = {
                 'name': certificate['name'],
@@ -113,19 +113,19 @@ class CertificateUseCase3Test(APITestCase):
             response = self.client.delete(
                 '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)
 
             # Assert data
             response = self.client.get('{}/{}'.format(self.url, certificate['name']))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -138,4 +138,4 @@ class CertificateUseCase3Test(APITestCase):
             )
             url = '/v2/certs/{}'.format(certificate['name'])
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/test_certificate_use_case_4.py
+++ b/rootfs/api/tests/test_certificate_use_case_4.py
@@ -76,7 +76,7 @@ class CertificateUseCase4Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
     def test_get_certificate_screens_data(self):
         """
@@ -93,20 +93,20 @@ class CertificateUseCase4Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
                 {'domain': domain}
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Assert data
             response = self.client.get(
                 '{}/{}'.format(self.url, certificate['name'])
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
 
             expected = {
                 'name': certificate['name'],
@@ -127,13 +127,13 @@ class CertificateUseCase4Test(APITestCase):
             response = self.client.delete(
                 '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)
 
             # Assert data
             response = self.client.get(
                 '{}/{}'.format(self.url, certificate['name'])
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(response.data['domains'], [])
 
     def test_certificate_attach_overwrite(self):
@@ -150,14 +150,14 @@ class CertificateUseCase4Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
         # Attach domain to certificate
         response = self.client.post(
             '{}/{}/domain/'.format(self.url, 'foo-com'),
             {'domain': 'foo.com'}
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Attach domain to a second certificate
         response = self.client.post(
@@ -171,7 +171,7 @@ class CertificateUseCase4Test(APITestCase):
         response = self.client.get(
             '{}/{}'.format(self.url, 'foo-com')
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         expected = {
             'name': 'foo-com',
@@ -188,7 +188,7 @@ class CertificateUseCase4Test(APITestCase):
         response = self.client.get(
             '{}/{}'.format(self.url, 'bar-com')
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         expected = {
             'name': 'bar-com',
@@ -205,9 +205,9 @@ class CertificateUseCase4Test(APITestCase):
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -220,4 +220,4 @@ class CertificateUseCase4Test(APITestCase):
             )
             url = '/v2/certs/{}'.format(certificate['name'])
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/test_certificate_use_case_5.py
+++ b/rootfs/api/tests/test_certificate_use_case_5.py
@@ -72,7 +72,7 @@ class CertificateUseCase5Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
     def test_get_certificate_screens_data(self):
         """
@@ -89,14 +89,14 @@ class CertificateUseCase5Test(APITestCase):
                     'key': certificate['key']
                 }
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             # Attach domain to certificate
             response = self.client.post(
                 '{}/{}/domain/'.format(self.url, certificate['name']),
                 {'domain': domain}
             )
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             if certificate['san']:
                 for san in certificate['san']:
@@ -104,13 +104,13 @@ class CertificateUseCase5Test(APITestCase):
                         '{}/{}/domain/'.format(self.url, certificate['name']),
                         {'domain': san}
                     )
-                    self.assertEqual(response.status_code, 201)
+                    self.assertEqual(response.status_code, 201, response.data)
 
             # Assert data
             response = self.client.get(
                 '{}/{}'.format(self.url, certificate['name'])
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
 
             expected = {
                 'name': certificate['name'],
@@ -131,28 +131,28 @@ class CertificateUseCase5Test(APITestCase):
             response = self.client.delete(
                 '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
             )
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)
 
             if certificate['san']:
                 for san in certificate['san']:
                     response = self.client.delete(
                         '{}/{}/domain/{}'.format(self.url, certificate['name'], san)
                     )
-                    self.assertEqual(response.status_code, 204)
+                    self.assertEqual(response.status_code, 204, response.data)
 
             # Assert data
             response = self.client.get(
                 '{}/{}'.format(self.url, certificate['name'])
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(response.data['domains'], [])
 
     def test_certficate_denied_requests(self):
         """Disallow put/patch requests"""
         response = self.client.put(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
         response = self.client.patch(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_certificate(self):
         """Destroying a certificate should generate a 204 response"""
@@ -168,4 +168,4 @@ class CertificateUseCase5Test(APITestCase):
             # Remove certificate
             url = '/v2/certs/{}'.format(certificate['name'])
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/test_domain.py
+++ b/rootfs/api/tests/test_domain.py
@@ -27,7 +27,7 @@ class DomainTest(APITestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.app_id = response.data['id']  # noqa
 
     def tearDown(self):
@@ -131,12 +131,12 @@ class DomainTest(APITestCase):
         ]
         for domain in test_domains:
             response = self.client.post(url, {'domain': domain})
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
         url = '/v2/apps/{app_id}/domains/{domain}'.format(domain=test_domains[0],
                                                           app_id=self.app_id)
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
         with self.assertRaises(Domain.DoesNotExist):
             Domain.objects.get(domain=test_domains[0])
 
@@ -184,12 +184,12 @@ class DomainTest(APITestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         url = '/v2/apps/{}/domains'.format(self.app_id)
         response = self.client.post(url, {'domain': 'example.deis.example.com'})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_unauthorized_user_cannot_modify_domain(self):
         """
@@ -222,16 +222,16 @@ class DomainTest(APITestCase):
             domain = 'foo.com'
             url = '/v2/apps/test/domains'
             response = self.client.post(url, {'domain': domain})
-            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.status_code, 503, response.data)
 
         # scheduler._update_service exception
         with mock.patch('scheduler.KubeHTTPClient._update_service') as mock_kube:
             domain = 'foo.com'
             url = '/v2/apps/test/domains'
             response = self.client.post(url, {'domain': domain})
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, 201, response.data)
 
             mock_kube.side_effect = KubeException('Boom!')
             url = '/v2/apps/test/domains/{domain}'.format(domain=domain)
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.status_code, 503, response.data)

--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -70,21 +70,21 @@ class KeyTest(APITestCase):
         url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         key_id = response.data['id']
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
 
         url = '/v2/keys/{key_id}'.format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(body['id'], response.data['id'])
         self.assertEqual(body['public'], response.data['public'])
 
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
     def _check_bad_key(self, pubkey):
         """
@@ -94,7 +94,7 @@ class KeyTest(APITestCase):
         body = {'id': 'mykey@box.local', 'public': pubkey}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         return response
 
     def test_rsa_key(self):
@@ -114,16 +114,16 @@ class KeyTest(APITestCase):
         url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         # test that adding a key with the same fingerprint fails
         body = {'id': 'mykey2@box.local', 'public': pubkey}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         body = {'id': 'mykey2@box.local', 'public': pubkey2}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
     def test_rsa_duplicate_key(self):
         self._check_duplicate_key(RSA_PUBKEY, RSA_PUBKEY2)
@@ -143,7 +143,7 @@ class KeyTest(APITestCase):
                 'b6PkOR4c+LS5WWXd2oM6HyBQBxxiwXbA2lSgQxOdgDiM2FzT0GVSFMUklkUH'
                 'MdsaG6/HJDw9QckTS0vN autotest@deis.io'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         key = Key.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(key), 'ssh-rsa AAAAB3NzaC.../HJDw9QckTS0vN autotest@deis.io')
 

--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -16,7 +16,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertTrue(response.data['is_superuser'])
 
         # register a second user
@@ -29,7 +29,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertFalse(response.data['is_superuser'])
 
     def test_list(self):
@@ -40,7 +40,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertTrue(response.data['is_superuser'])
 
         user = User.objects.get(username='firstuser')
@@ -48,7 +48,7 @@ class TestAdminPerms(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
 
         response = self.client.get('/v2/admin/perms')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['username'], 'firstuser')
         self.assertTrue(response.data['results'][0]['is_superuser'])
@@ -61,7 +61,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertFalse(response.data['is_superuser'])
 
         user = User.objects.get(username='seconduser')
@@ -80,7 +80,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertTrue(response.data['is_superuser'])
 
         submit = {
@@ -90,7 +90,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertFalse(response.data['is_superuser'])
 
         user = User.objects.get(username='first')
@@ -100,9 +100,9 @@ class TestAdminPerms(APITestCase):
         url = '/v2/admin/perms'
         body = {'username': 'second'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
         self.assertIn('second', str(response.data['results']))
 
@@ -114,7 +114,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertTrue(response.data['is_superuser'])
 
         submit = {
@@ -124,7 +124,7 @@ class TestAdminPerms(APITestCase):
         }
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertFalse(response.data['is_superuser'])
 
         user = User.objects.get(username='first')
@@ -134,13 +134,13 @@ class TestAdminPerms(APITestCase):
         url = '/v2/admin/perms'
         body = {'username': 'second'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # revoke the superuser perm
         response = self.client.delete(url + '/second')
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         self.assertNotIn('two', str(response.data['results']))
 
@@ -164,7 +164,7 @@ class TestAppPerms(APITestCase):
         # check that user 1 sees her lone app and user 2's app
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
 
@@ -187,12 +187,12 @@ class TestAppPerms(APITestCase):
         body = {'username': 'autotest-2'}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # check that user 2 can see the app
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
 
         # check that user 2 sees (empty) results now for builds, containers,
@@ -222,19 +222,19 @@ class TestAppPerms(APITestCase):
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # check that user 2 can see the app as well as his own
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token2)
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
 
         # delete permission to user 1's app
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         url = "/v2/apps/{}/perms/{}".format(app_id, 'autotest-2')
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
         self.assertIsNone(response.data)
 
         # check that user 2 can only see his app
@@ -250,7 +250,7 @@ class TestAppPerms(APITestCase):
     def test_list(self):
         # check that user 1 sees her lone app and user 2's app
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
 
@@ -258,7 +258,7 @@ class TestAppPerms(APITestCase):
         url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # list perms on the app
         response = self.client.get("/v2/apps/{}/perms".format(app_id))
@@ -267,7 +267,7 @@ class TestAppPerms(APITestCase):
     def test_admin_can_list(self):
         """Check that an administrator can list an app's perms"""
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 2)
 
     def test_list_errors(self):
@@ -311,7 +311,7 @@ class TestAppPerms(APITestCase):
         body = {'username': collab.username}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # Collaborator should fail to share app
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + collab_token)
@@ -321,16 +321,16 @@ class TestAppPerms(APITestCase):
 
         # Collaborator can list
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # Share app with user 3 for rest of tests
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + collab_token)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # Collaborator cannot delete other collaborator
         url += "/{}".format(self.user3.username)
@@ -340,4 +340,4 @@ class TestAppPerms(APITestCase):
         # Collaborator can delete themselves
         url = '/v2/apps/{}/perms/{}'.format(app_id, collab.username)
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -42,13 +42,13 @@ class PodTest(APITransactionTestCase):
     def test_container_api_heroku(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # should start with zero
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         # post a new build
@@ -62,27 +62,27 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         # test setting one proc type at a time
         body = {'web': 4}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         body = {'worker': 2}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 6)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         # ensure the structure field is up-to-date
         self.assertEqual(response.data['structure']['web'], 4)
         self.assertEqual(response.data['structure']['worker'], 2)
@@ -90,14 +90,14 @@ class PodTest(APITransactionTestCase):
         # test listing/retrieving container info
         url = "/v2/apps/{app_id}/pods/web".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.data['count'], 4)
         self.assertEqual(len(response.data['results']), 4)
 
         name = response.data['results'][0]['name']
         url = "/v2/apps/{app_id}/pods/web/{name}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['name'], name)
 
@@ -106,16 +106,16 @@ class PodTest(APITransactionTestCase):
         # test setting two proc types at a time
         body = {'web': 2, 'worker': 1}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 3)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         # ensure the structure field is up-to-date
         self.assertEqual(response.data['structure']['web'], 2)
         self.assertEqual(response.data['structure']['worker'], 1)
@@ -124,27 +124,27 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0, 'worker': 0}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
     def test_container_api_docker(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # should start with zero
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         # post a new build
@@ -154,69 +154,69 @@ class PodTest(APITransactionTestCase):
             'dockerfile': "FROM busybox\nCMD /bin/true"
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'cmd': 6}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 6)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # test listing/retrieving container info
         url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 6)
 
         # scale down
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'cmd': 3}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 3)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # scale down to 0
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'cmd': 0}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
     def test_release(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # should start with zero
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         # post a new build
@@ -230,17 +230,17 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 1}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['release'], 'v2')
 
@@ -254,12 +254,12 @@ class PodTest(APITransactionTestCase):
             }
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['image'], body['image'])
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['release'], 'v3')
 
@@ -267,18 +267,18 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/config".format(**locals())
         body = {'values': json.dumps({'KEY': 'value'})}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['release'], 'v4')
 
     def test_container_errors(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # create a release so we can scale
@@ -298,7 +298,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 'not_an_int'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         self.assertEqual(response.data, {'detail': "Invalid scaling format: invalid literal for "
                                                    "int() with base 10: 'not_an_int'"})
         body = {'invalid': 1}
@@ -309,7 +309,7 @@ class PodTest(APITransactionTestCase):
         """Test the text representation of a container."""
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -323,18 +323,18 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 4, 'worker': 2}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # should start with zero
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 6)
         pods = response.data['results']
         for pod in pods:
@@ -347,7 +347,7 @@ class PodTest(APITransactionTestCase):
         # regression test for https://github.com/deis/deis/pull/1285
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -361,18 +361,18 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 1}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
 
         # verify that the app._get_command property got formatted
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 1)
 
         pod = response.data['results'][0]
@@ -388,13 +388,13 @@ class PodTest(APITransactionTestCase):
     def test_scale_errors(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # should start with zero
         url = "/v2/apps/{app_id}/pods".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data['results']), 0)
 
         # post a new build
@@ -408,37 +408,37 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # scale to a negative number
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': -1}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
 
         # scale to something other than a number
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 'one'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
 
         # scale to something other than a number
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': [1]}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
 
         # scale up to an integer as a sanity check
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 1}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         with mock.patch('scheduler.KubeHTTPClient.scale') as mock_kube:
             mock_kube.side_effect = KubeException('Boom!')
             url = "/v2/apps/{app_id}/scale".format(**locals())
             response = self.client.post(url, {'web': 10})
-            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.status_code, 503, response.data)
 
     def test_admin_can_manage_other_pods(self, mock_requests):
         """If a non-admin user creates a container, an administrator should be able to
@@ -450,7 +450,7 @@ class PodTest(APITransactionTestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -464,13 +464,13 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # login as admin, scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 4, 'worker': 2}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
     def test_scale_without_build_should_error(self, mock_requests):
         """A user should not be able to scale processes unless a build is present."""
@@ -482,14 +482,14 @@ class PodTest(APITransactionTestCase):
         url = '/v2/apps/{app_id}/scale'.format(**locals())
         body = {'web': '1'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400, response.data)
         self.assertEqual(response.data, {'detail': 'No build associated with this release'})
 
     def test_command_good(self, mock_requests):
         """Test the default command for each container workflow"""
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         app = App.objects.get(id=app_id)
         user = User.objects.get(username='autotest')
@@ -547,7 +547,7 @@ class PodTest(APITransactionTestCase):
         """Test the run command for each container workflow"""
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         app = App.objects.get(id=app_id)
 
@@ -577,7 +577,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/run".format(**locals())
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
         self.assertEqual(entrypoint, '/bin/bash')
 
@@ -588,7 +588,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/run".format(**locals())
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
         self.assertEqual(entrypoint, '/bin/bash')
 
@@ -598,7 +598,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/run".format(**locals())
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
         self.assertEqual(entrypoint, '/runner/init')
 
@@ -611,7 +611,7 @@ class PodTest(APITransactionTestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         app = App.objects.get(id=app_id)
 
@@ -641,7 +641,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/run".format(**locals())
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
         self.assertEqual(entrypoint, '/bin/bash')
 
@@ -649,7 +649,7 @@ class PodTest(APITransactionTestCase):
         """Test that app info doesn't show transient "run" proctypes."""
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
         app = App.objects.get(id=app_id)
         user = User.objects.get(username='autotest')
@@ -680,18 +680,18 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/run".format(**locals())
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
 
         # scale up
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 3}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # test that "run" proctype isn't in the app info returned
         url = "/v2/apps/{app_id}".format(**locals())
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertNotIn('run', response.data['structure'])
 
     def test_scale_with_unauthorized_user_returns_403(self, mock_requests):
@@ -702,7 +702,7 @@ class PodTest(APITransactionTestCase):
         """
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -730,7 +730,7 @@ class PodTest(APITransactionTestCase):
         """
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -748,7 +748,7 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 4}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         body = {
             'image': 'autotest/example',
@@ -758,7 +758,7 @@ class PodTest(APITransactionTestCase):
             })
         }
         response = self.client.post(build_url, body)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
 
         # make sure no pods are web
         application = App.objects.get(id=app_id)
@@ -768,7 +768,7 @@ class PodTest(APITransactionTestCase):
     def test_restart_pods(self, mock_requests):
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         # post a new build
@@ -786,26 +786,26 @@ class PodTest(APITransactionTestCase):
         url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 4, 'worker': 8}
         response = self.client.post(url, body)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 204, response.data)
 
         # setup app object
         application = App.objects.get(id=app_id)
 
         # restart all pods
         response = self.client.post('/v2/apps/{}/pods/restart'.format(app_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         # Compare restarted pods to all pods
         self.assertEqual(len(response.data), 12)
 
         # restart only the workers
         response = self.client.post('/v2/apps/{}/pods/worker/restart'.format(app_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         # Compare restarted pods to only worker pods
         self.assertEqual(len(response.data), 8)
 
         # restart only the web
         response = self.client.post('/v2/apps/{}/pods/web/restart'.format(app_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         # Compare restarted pods to only worker pods
         self.assertEqual(len(response.data), 4)
 
@@ -815,14 +815,14 @@ class PodTest(APITransactionTestCase):
 
         pod = pods.pop()
         response = self.client.post('/v2/apps/{}/pods/web/{}/restart'.format(app_id, pod['name']))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['type'], 'web')
 
         # restart only one web port but using the short name of web-asdfg
         name = 'web-' + pod['name'].split('-').pop()
         response = self.client.post('/v2/apps/{}/pods/web/{}/restart'.format(app_id, name))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['type'], 'web')
 
@@ -833,7 +833,7 @@ class PodTest(APITransactionTestCase):
 
         url = '/v2/apps'
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
         with mock.patch('scheduler.KubeHTTPClient._get_pod') as kube_pod:
@@ -842,4 +842,4 @@ class PodTest(APITransactionTestCase):
                 kube_pods.side_effect = KubeException('boom!')
                 url = "/v2/apps/{app_id}/pods".format(**locals())
                 response = self.client.get(url)
-                self.assertEqual(response.status_code, 503)
+                self.assertEqual(response.status_code, 503, response.data)

--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -17,7 +17,7 @@ class TestUsers(APITestCase):
         for url in ['/v2/users', '/v2/users/']:
             response = self.client.get(url,
                                        HTTP_AUTHORIZATION='token {}'.format(token))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):


### PR DESCRIPTION
I triggered an error as an example:

```
======================================================================
FAIL: test_app (api.tests.test_app.AppTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 600, in run
    testMethod()
  File "/Users/helgi/projects/deis/controller/venv/src/request-mock/requests_mock/mocker.py", line 180, in inner
    return func(*args, **kwargs)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/mock.py", line 1157, in patched
    return func(*args, **keywargs)
  File "/Users/helgi/projects/deis/controller/rootfs/api/tests/test_app.py", line 55, in test_app
    self.assertEqual(response.status_code, 200, response.data)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 820, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 813, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 201 != 200 : {'owner': 'autotest', 'created': '2016-05-10T16:50:44Z', 'id': 'dapper-windmill', 'uuid': 'b84fccb8-68ef-408d-820b-652dbe32304c', 'structure': {}, 'updated': '2016-05-10T16:50:44Z'}
```

In a diff PR I'll look if I can make those AssertError exceptions look a little easier to read o_O