### PR TITLE
ref(scheduler): rework the way deis run is handled, timeouts and more

### DIFF
--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -578,7 +578,8 @@ class PodTest(APITransactionTestCase):
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)
-        entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
         self.assertEqual(entrypoint, '/bin/bash')
 
         # docker image workflow
@@ -589,7 +590,8 @@ class PodTest(APITransactionTestCase):
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)
-        entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
         self.assertEqual(entrypoint, '/bin/bash')
 
         # procfile workflow
@@ -599,12 +601,13 @@ class PodTest(APITransactionTestCase):
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)
-        entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
         self.assertEqual(entrypoint, '/runner/init')
 
     def test_run_not_fail_on_debug(self, mock_requests):
         """
-        do a run with DEBUG on - https://github.com/deis/controller/issues/583
+        do a run with DEIS_DEBUG on - https://github.com/deis/controller/issues/583
         """
         env = EnvironmentVarGuard()
         env['DEIS_DEBUG'] = 'true'
@@ -642,7 +645,8 @@ class PodTest(APITransactionTestCase):
         body = {'command': 'echo hi'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)
-        entrypoint = json.loads(response.data['output'])['spec']['containers'][0]['command'][0]
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
         self.assertEqual(entrypoint, '/bin/bash')
 
     def test_scaling_does_not_add_run_proctypes_to_structure(self, mock_requests):

--- a/rootfs/api/tests/test_scheduler_states.py
+++ b/rootfs/api/tests/test_scheduler_states.py
@@ -1,0 +1,30 @@
+import unittest
+from scheduler.states import PodState
+
+
+class TestSchedulerStates(unittest.TestCase):
+    """Test Scheduler States OrderedEnum"""
+
+    def test_gt_comparison(self):
+        self.assertTrue(PodState.up > PodState.starting)
+        self.assertFalse(PodState.starting > PodState.up)
+        with self.assertRaises(TypeError):
+            self.assertTrue(PodState.up > 'starting')
+
+    def test_ge_comparison(self):
+        self.assertTrue(PodState.up >= PodState.starting)
+        self.assertFalse(PodState.starting >= PodState.up)
+        with self.assertRaises(TypeError):
+            self.assertTrue(PodState.up >= 'starting')
+
+    def test_lt_comparison(self):
+        self.assertFalse(PodState.up < PodState.starting)
+        self.assertTrue(PodState.starting < PodState.up)
+        with self.assertRaises(TypeError):
+            self.assertTrue(PodState.up < 'crashed')
+
+    def test_le_comparison(self):
+        self.assertFalse(PodState.up <= PodState.starting)
+        self.assertTrue(PodState.starting <= PodState.up)
+        with self.assertRaises(TypeError):
+            self.assertTrue(PodState.up <= 'crashed')

--- a/rootfs/deis/testing.py
+++ b/rootfs/deis/testing.py
@@ -2,6 +2,15 @@ import random
 import string
 from deis.settings import *  # noqa
 
+# A boolean that turns on/off debug mode.
+# https://docs.djangoproject.com/en/1.9/ref/settings/#debug
+DEBUG = True
+
+# If set to True, Django's normal exception handling of view functions
+# will be suppressed, and exceptions will propagate upwards
+# https://docs.djangoproject.com/en/1.9/ref/settings/#debug-propagate-exceptions
+DEBUG_PROPAGATE_EXCEPTIONS = True
+
 # scheduler for testing
 SCHEDULER_MODULE = 'scheduler.mock'
 SCHEDULER_URL = 'http://test-scheduler.example.com'

--- a/rootfs/scheduler/states.py
+++ b/rootfs/scheduler/states.py
@@ -1,7 +1,34 @@
-import enum
+from enum import Enum, unique
 
 
-class JobState(enum.Enum):
+class OrderedEnum(Enum):
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+
+        return NotImplemented
+
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+
+        return NotImplemented
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+
+        return NotImplemented
+
+
+@unique
+class PodState(OrderedEnum):
     initializing = 1
     creating = 2
     starting = 3
@@ -11,3 +38,7 @@ class JobState(enum.Enum):
     destroyed = 7
     crashed = 8
     error = 9
+
+    def __str__(self):
+        """Return the name of the state"""
+        return self.name


### PR DESCRIPTION
# Summary of Changes

Use the same "is the pod ready" function as normal deployments, also give deis run 20 mins max (arbitrary but is somewhat what the gunicorn worker can do)

On failure the whole Pod manifest is no longer returned. This change affects how we do tests here but minimally

Mocking was improved to help move a Pod from Pending to Running and if it is a deis run Pod (not attached to RC) then it also goes to Succeeded state. This helps with test coverage but is not the full Pod state transition route

# Issue(s) that this PR Closes

Fixes #681
Fixes #590

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

deis run already has e2e

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

Documentation still needs to be updated to handle the little change in API

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. run a `deis run` command
4. things should work!

