### PR TITLE
fix(scheduler): do not update env secret if it already exists

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -632,8 +632,6 @@ class KubeHTTPClient(object):
                     'type': 'env'
                 }
                 self._create_secret(namespace, secret_name, secrets_env, labels=labels)
-            else:
-                self._update_secret(namespace, secret_name, secrets_env)
 
             for key in env.keys():
                 data["env"].append({


### PR DESCRIPTION
There is a env secret per version, no point in updating it along the way

If there are many process types then the following ones will *update* the secret and drop the *important* labels