### PR TITLE
ref(deis run): change the /run API to use exit_code instead of rc for  the exit code value

### DIFF
--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -282,7 +282,7 @@ class AppTest(APITestCase):
         body = {'command': 'ls -al'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)
-        self.assertEqual(response.data['rc'], 0)
+        self.assertEqual(response.data['exit_code'], 0)
         self.assertEqual(response.data['output'], 'mock')
 
     def test_run_failure(self, mock_requests):

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -227,7 +227,7 @@ class AppViewSet(BaseDeisViewSet):
     def run(self, request, **kwargs):
         app = self.get_object()
         rc, output = app.run(self.request.user, request.data['command'])
-        return Response({'rc': rc, 'output': str(output)})
+        return Response({'exit_code': rc, 'output': str(output)})
 
     def update(self, request, **kwargs):
         app = self.get_object()


### PR DESCRIPTION
Depends on https://github.com/deis/controller/pull/738