### PR TITLE
fix(scheduler): cast PodState to string to get state name

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -620,7 +620,7 @@ class App(UuidAuditedModel):
                 if p['metadata']['labels']['type'] == 'run':
                     continue
 
-                state = self._scheduler._pod_state(p).name
+                state = str(self._scheduler._pod_state(p))
 
                 # follows kubelete convention - these are hidden unless show-all is set
                 if state in ['down', 'crashed']:

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -603,7 +603,7 @@ class KubeHTTPClient(object):
             while (state == 'up' and waited < timeout):
                 response = self._get_pod(namespace, name)
                 pod = response.json()
-                state = self._pod_state(pod).name
+                state = str(self._pod_state(pod))
                 # default data
                 exit_code = 0
 


### PR DESCRIPTION
Not all _pod_state() returns are an Object right now, this is a quick fix for that problem