### PR TITLE
ref(exceptions/logging): unify logging and make sure exceptions go into logs

### DIFF
--- a/rootfs/api/exceptions.py
+++ b/rootfs/api/exceptions.py
@@ -1,3 +1,38 @@
-class HealthcheckException(Exception):
+import logging
+from rest_framework.compat import set_rollback
+from rest_framework.exceptions import APIException, status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+class HealthcheckException(APIException):
     """Exception class used for when the application's health check fails"""
     pass
+
+
+class DeisException(APIException):
+    status_code = 400
+
+
+class AlreadyExists(APIException):
+    status_code = 409
+
+
+class ServiceUnavailable(APIException):
+    status_code = 503
+    default_detail = 'Service temporarily unavailable, try again later.'
+
+
+def custom_exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+
+    # No response means DRF couldn't handle it
+    # Output a generic 500 in a JSON format
+    if response is None:
+        logging.exception('Uncaught Exception', exc_info=exc)
+        set_rollback()
+        return Response({'detail': 'Server Error'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return response

--- a/rootfs/api/models/certificate.py
+++ b/rootfs/api/models/certificate.py
@@ -188,7 +188,9 @@ class Certificate(AuditedModel):
                 try:
                     self._scheduler._update_secret(app, name, data)
                 except KubeException as e:
-                    raise ServiceUnavailable(str(e)) from e
+                    msg = 'There was a problem updating the certificate secret ' \
+                          '{} for {}'.format(name, app)
+                    raise ServiceUnavailable(msg) from e
 
         # get config for the service
         config = self._load_service_config(app, 'router')

--- a/rootfs/api/models/key.py
+++ b/rootfs/api/models/key.py
@@ -13,7 +13,7 @@ def validate_base64(value):
     try:
         base64.b64decode(value.split()[1])
     except Exception as e:
-        raise ValidationError(str(e))
+        raise ValidationError('Key contains invalid base64 chars') from e
 
 
 class Key(UuidAuditedModel):

--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -105,7 +105,7 @@ class KeyTest(APITestCase):
 
     def test_bad_key(self):
         response = self._check_bad_key(BAD_KEY)
-        self.assertEqual(response.data, {'public': ['Incorrect padding']})
+        self.assertEqual(response.data, {'public': ['Key contains invalid base64 chars']})
 
     def _check_duplicate_key(self, pubkey, pubkey2):
         """

--- a/rootfs/deis/gconf.py
+++ b/rootfs/deis/gconf.py
@@ -1,4 +1,6 @@
 import os
+import faulthandler
+faulthandler.enable()
 
 bind = '0.0.0.0'
 try:

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -159,19 +159,18 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'EXCEPTION_HANDLER': 'api.exceptions.custom_exception_handler'
 }
 
 # URLs that end with slashes are ugly
 APPEND_SLASH = False
 
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'root': {'level': 'DEBUG' if DEBUG else 'INFO'},
     'formatters': {
         'verbose': {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
@@ -183,6 +182,9 @@ LOGGING = {
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue'
         }
     },
     'handlers': {
@@ -194,37 +196,30 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
-        },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
+        }
     },
     'loggers': {
         'django': {
-            'handlers': ['null'],
-            'level': 'INFO',
+            'handlers': ['console'],
+            'filters': ['require_debug_true'],
             'propagate': True,
         },
         'django.request': {
-            'handlers': ['console', 'mail_admins'],
+            'handlers': ['console'],
             'level': 'WARNING',
+            'filters': ['require_debug_true'],
             'propagate': True,
         },
         'api': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
+            'handlers': ['console'],
             'propagate': True,
         },
         'registry': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
+            'handlers': ['console'],
             'propagate': True,
         },
         'scheduler': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'DEBUG',
+            'handlers': ['console'],
             'propagate': True,
         },
     }

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -13,3 +13,6 @@ codecov==2.0.3
 
 # tblib is needed to pickle tracebacks for `make test-unit-quick`
 tblib==1.3.0
+
+# tail a log and pipe into tbgrep to find all tracebacks
+tbgrep==0.3.0

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,5 +1,4 @@
 # Deis controller requirements
-#
 Django==1.9.6
 django-cors-headers==1.1.0
 django-guardian==1.4.4


### PR DESCRIPTION
## Summary of Changes

Add a custom exception handler to deal with uncaught exceptions so they get properly logged to the stdout logging, and also return a 500 with a JSON body like everything else does.
A lot of scheduling logging has moved up from debug to info (the new default value) and now DEBUG=True (in the django config file) will cause debug information to outputting

`tbgrep` was added, usage would be `k logs -f <controller pod> | tbgrep`

One thing I started doing in this PR is to reduce the `str(e)` as the msg to Exceptions, instead writing more generic message and chaining the Exceptions to together which in turn get logged.

The idea for that is to show end users less internal error messages in API responses but still make it available to the Operator

## Issue(s) that this PR Closes

Please list the issue(s) that this PR closes, similar to the below:

fixes #568
ref #612