### PR TITLE
fix(scheduler): don't match container names in "deis run"

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -1490,7 +1490,7 @@ class KubeHTTPClient(object):
         name = '{}-{}'.format(pod['metadata']['labels']['app'], pod['metadata']['labels']['type'])
         for container in pod['status']['containerStatuses']:
             # find the right container in case there are many on the pod
-            if container['name'] != name:
+            if container['name'] != name and not name.endswith("-run"):
                 continue
 
             if not container['ready']:


### PR DESCRIPTION
# Summary of Changes

Skips the container name comparison in the case of a `deis run`-spawned pod, since they won't match. (`name` will be something like "nonfat-jailbird-run" but the container's name might be "nonfat-jailbird-v2-run-6atqv".) Using the first (only) container in the pod should be fine in this case.

This change fixes the error in my testing, and I always get the proper exit code back from `deis` now.

# Issue(s) that this PR Closes

Closes #748.

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

refs deis/workflow-e2e#212

# Testing Instructions

Run a nonexistent deis run command, or one that returns non-zero, then query the `deis` CLI return code:
```console
$ deis run boguscmd
$ echo $?
```

A non-zero exit code should *always* be returned. This error isn't deterministic so you should repeat the test many times.

# Pull Request Hygiene TODOs

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom:

