### PR TITLE
fix(scheduler): run pod container name did not match how app containers are done

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -36,7 +36,7 @@ POD_BTEMPLATE = """\
   "spec": {
     "containers": [
       {
-        "name": "$id",
+        "name": "$containername",
         "image": "$image",
         "env": [
         {
@@ -99,7 +99,7 @@ POD_TEMPLATE = """\
   "spec": {
     "containers": [
       {
-        "name": "$id",
+        "name": "$containername",
         "image": "$image",
         "env": []
       }
@@ -537,9 +537,11 @@ class KubeHTTPClient(object):
             name, image, entrypoint, command)
         )
 
+        app_type = 'run'
         POD = POD_TEMPLATE
         l = {
             'id': name,
+            'containername': namespace + '-' + app_type,
             'app': namespace,
             'appversion': kwargs.get('version'),
             'type': 'run',
@@ -588,7 +590,7 @@ class KubeHTTPClient(object):
 
         labels = {
             'app': namespace,
-            'type': 'run',
+            'type': app_type,
             'version': kwargs.get('version'),
             'heritage': 'deis',
         }


### PR DESCRIPTION
# Summary of Changes

Instead of using the `Pod` name for `run` templates then instead use the same container name logic as normal application `Pods` have on their app `Container`

# Issue(s) that this PR Closes

Fixes #748
Replaces #749