### PR TITLE
fix(gunicorn): silence healthcheck points in access logs

### DIFF
--- a/rootfs/deis/gconf.py
+++ b/rootfs/deis/gconf.py
@@ -2,6 +2,7 @@ import os
 import faulthandler
 faulthandler.enable()
 
+
 bind = '0.0.0.0'
 try:
     workers = int(os.environ.get('GUNICORN_WORKERS', 'not set'))
@@ -13,8 +14,11 @@ except (NameError, ValueError):
         workers = multiprocessing.cpu_count() * 2 + 1
     except NotImplementedError:
         workers = 8
+
+pythonpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 timeout = 1200
 pidfile = '/tmp/gunicorn.pid'
+logger_class = 'deis.logging.Logging'
 loglevel = 'info'
 errorlog = '-'
 accesslog = '-'

--- a/rootfs/deis/logging.py
+++ b/rootfs/deis/logging.py
@@ -1,0 +1,14 @@
+import os
+from gunicorn.glogging import Logger
+
+
+class Logging(Logger):
+    def access(self, resp, req, environ, request_time):
+        # health check endpoints are only logged in debug mode
+        if (
+            not os.environ.get('DEIS_DEBUG', False) and
+            req.path in ['/readiness', '/healthz']
+        ):
+            return
+
+        Logger.access(self, resp, req, environ, request_time)


### PR DESCRIPTION
If `DEIS_DEBUG` is set then they show up again

Testing Plan:
* `make deploy` on this branch
* `kubectl logs -f <controller pod> --namespace deis`
* See if `/healtz` or `/readiness` show up in the logs (they should not)
* Do any `deis` CLI action and ensure those endpoints show up in the access log

If `DEIS_DEBUG` is set then the those requests should show

Fixes #252