### PR TITLE
ref(gunicorn): use os.cpu_count instead of multiprocessing for simplification

### DIFF
--- a/rootfs/deis/gunicorn/config.py
+++ b/rootfs/deis/gunicorn/config.py
@@ -10,11 +10,7 @@ try:
     if workers < 1:
         raise ValueError()
 except (NameError, ValueError):
-    import multiprocessing
-    try:
-        workers = multiprocessing.cpu_count() * 2 + 1
-    except NotImplementedError:
-        workers = 8
+    workers = (os.cpu_count() or 4) * 2 + 1
 
 pythonpath = dirname(dirname(dirname(realpath(__file__))))
 timeout = 1200


### PR DESCRIPTION
Use `os.cpu_count` instead of `multiprocessing` (they are pretty much the same) - Got added in 3.4: https://docs.python.org/3/library/os.html#os.cpu_count

https://bugs.python.org/issue17914

The default change may seem deceiving but the move from 8 to 4 actually ends up as 9 if CPUs can't be found, due to the math we do

Depends on #758