### PR TITLE
fix(api): fail when rolling back to v1

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -217,6 +217,8 @@ class Release(UuidAuditedModel):
 
             if version < 1:
                 raise DeisException('version cannot be below 0')
+            elif version == 1:
+                raise DeisException('Cannot roll back to initial release.')
 
             prev = self.app.release_set.get(version=version)
             new_release = self.new(


### PR DESCRIPTION
# Summary of Changes

v1 is an intial release created when `deis create` is called, but
does not contain any build information.

# Issue(s) that this PR Closes

addresses https://github.com/deis/workflow/issues/275#issuecomment-222801645

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

N/A

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

N/A

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: