### PR TITLE
fix(scheduler): update instead of appending env vars so hardcoded values can be overwritten

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -664,7 +664,7 @@ class KubeHTTPClient(object):
                 self._create_secret(namespace, secret_name, secrets_env, labels=labels)
 
             for key in env.keys():
-                data["env"].append({
+                item = {
                     "name": key,
                     "valueFrom": {
                         "secretKeyRef": {
@@ -673,7 +673,14 @@ class KubeHTTPClient(object):
                             "key": key.lower().replace('_', '-')
                         }
                     }
-                })
+                }
+
+                # add value to env hash. Overwrite hardcoded values if need be
+                match = next((k for k, e in enumerate(data["env"]) if e['name'] == key), None)
+                if match is not None:
+                    data["env"][match] = item
+                else:
+                    data["env"].append(item)
 
         # Inject debugging if workflow is in debug mode
         if os.environ.get("DEIS_DEBUG", False):


### PR DESCRIPTION
# Summary of Changes

An example of this would be a user wanting to overwrite a hardcoded `PORT` or one of the other values Deis may set. Generally people should not do that, however the flexibility should be there in case they want to play with fire

if outputting the information for a given Pod this would be seen - 2x `PORT`
```
      env:
      - name: PORT
        value: "5000"
      - name: DEIS_APP
        value: finest-rosewood
      - name: PORT
        valueFrom:
          secretKeyRef:
            key: port
            name: finest-rosewood-v2-env
```

This should only show up once

# Issue(s) that this PR Closes

Fixes #766

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. push a buildpack app

Also, please provide a description of the desired result after the tester completes the above steps.

1. The app called "abcd" should be deployed
2. `kubectl get pod --namespace=abcd` should show 1 pod running
3. Get pod information and make sure only one `PORT` definition is available