### PR TITLE
fix(scheduler): remove the hardcoded port from RC template

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -40,10 +40,6 @@ POD_BTEMPLATE = """\
         "image": "$image",
         "env": [
         {
-            "name":"PORT",
-            "value":"5000"
-        },
-        {
             "name":"SLUG_URL",
             "value":"$slug_url"
         },
@@ -204,10 +200,6 @@ RCB_TEMPLATE = """\
             "image": "$image",
             "imagePullPolicy": "$image_pull_policy",
             "env": [
-            {
-                "name":"PORT",
-                "value":"5000"
-            },
             {
                 "name":"SLUG_URL",
                 "value":"$slug_url"


### PR DESCRIPTION
Not all applications will expose a port (non-routable ones)

This builds on top of #769


## Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

* Create a Deis Cluster
* Register an app
* push a buildpack app

Also, please provide a description of the desired result after the tester completes the above steps.

* The app called "abcd" should be deployed
* kubectl get pod --namespace=abcd should show 1 pod running
* Get pod information and make sure only one PORT definition is available