### PR TITLE
fix(app): only add a PORT env var if there is a value

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -331,7 +331,9 @@ class App(UuidAuditedModel):
             # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
             routable = True if scale_type in ['web', 'cmd'] else False
             # fetch application port and inject into ENV Vars as needed
-            envs['PORT'] = release.get_port(routable)
+            port = release.get_port(routable)
+            if port:
+                envs['PORT'] = port
 
             kwargs = {
                 'memory': release.config.memory,
@@ -384,7 +386,9 @@ class App(UuidAuditedModel):
             # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
             routable = True if scale_type in ['web', 'cmd'] else False
             # fetch application port and inject into ENV vars as needed
-            envs['PORT'] = release.get_port(routable)
+            port = release.get_port(routable)
+            if port:
+                envs['PORT'] = port
 
             deploys[scale_type] = {
                 'memory': release.config.memory,


### PR DESCRIPTION
# Summary of Changes

Only set the `PORT` env var if any was found.  By default it seems that k8s / docker will populate `$PORT` based on the service anyway unless we overwrite with our own value

Depends on #769 and #770

# Issue(s) that this PR Closes

Fixes #767 
Fixes https://github.com/deis/workflow/issues/275

# Testing Instructions

It is best to follow the testing steps in the previous tickets and/or what @slack outlined in https://github.com/deis/workflow/issues/275