### PR TITLE
fix(scheduler): cast ports to int before passing them on to k8s

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -464,7 +464,7 @@ class KubeHTTPClient(object):
                 for pos, item in enumerate(service['spec']['ports']):
                     if item['port'] == 80 and port != item['targetPort']:
                         # port 80 is the only one we care about right now
-                        service['spec']['ports'][pos]['targetPort'] = port
+                        service['spec']['ports'][pos]['targetPort'] = int(port)
 
             self._update_service(namespace, namespace, data=service)
         except Exception as e:
@@ -1181,7 +1181,7 @@ class KubeHTTPClient(object):
                 # an http probe
                 'httpGet': {
                     'path': path,
-                    'port': port
+                    'port': int(port)
                 },
                 # length of time to wait for a pod to initialize
                 # after pod startup, before applying health checking
@@ -1195,7 +1195,7 @@ class KubeHTTPClient(object):
                 # an http probe
                 'httpGet': {
                     'path': path,
-                    'port': port
+                    'port': int(port)
                 },
                 # length of time to wait for a pod to initialize
                 # after pod startup, before applying health checking
@@ -1264,7 +1264,7 @@ class KubeHTTPClient(object):
             'readinessProbe': {
                 # an exec probe
                 'tcpSocket': {
-                    "port": port
+                    "port": int(port)
                 },
                 # length of time to wait for a pod to initialize
                 # after pod startup, before applying health checking


### PR DESCRIPTION
when doing config:set PORT=80 then k8s complains that 80 is not a valid port / name

```
deis config:set PORT=80 -a zanier-zirconia
Creating config... Error:
400 Bad Request
detail: zanier-zirconia-v3-cmd (app::deploy): failed to create ReplicationController "zanier-zirconia-v3-cmd" in Namespace "zanier-zirconia": 422 status code 422
{'metadata': {}, 'kind': 'Status', 'reason': 'Invalid', 'status': 'Failure', 'message': 'ReplicationController "zanier-zirconia-v3-cmd" is invalid: spec.template.spec.containers[0].readinessProbe.tcpSocket.port: Invalid value: "80": must be an IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*[a-z0-9])*, it must contain at least one letter [a-z], and hyphens cannot be adjacent to other hyphens): e.g. "http"', 'code': 422, 'apiVersion': 'v1', 'details': {'causes': [{'message': 'Invalid value: "80": must be an IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*[a-z0-9])*, it must contain at least one letter [a-z], and hyphens cannot be adjacent to other hyphens): e.g. "http"', 'field': 'spec.template.spec.containers[0].readinessProbe.tcpSocket.port', 'reason': 'FieldValueInvalid'}], 'name': 'zanier-zirconia-v3-cmd', 'kind': 'ReplicationController'}}
```

Test is to run the above `config:set` and not get the error