### PR TITLE
fix(logs): retry fetching logs from the logger 3 times if the services is unavailable

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -1,3 +1,4 @@
+import backoff
 from collections import OrderedDict
 from datetime import datetime
 import logging
@@ -541,6 +542,7 @@ class App(UuidAuditedModel):
             level=logging.DEBUG
         )
 
+    @backoff.on_exception(backoff.expo, ServiceUnavailable, max_tries=3)
     def logs(self, log_lines=str(settings.LOG_LINES)):
         """Return aggregated log data for this application."""
         try:

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,4 +1,5 @@
 # Deis controller requirements
+backoff==1.2.1
 Django==1.9.7
 django-cors-headers==1.1.0
 django-guardian==1.4.4


### PR DESCRIPTION
Using `backoff` instead of `retrying` since it offers the ability (built in) to retry on certain exceptions and is also still maintained

Fixes #676