### PR TITLE
feat(release): throw 409 when identical release is done sequantially

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -5,7 +5,8 @@ from django.db import models
 
 from registry import publish_release, get_port as docker_get_port, RegistryException
 from api.utils import dict_diff
-from api.models import UuidAuditedModel, DeisException
+from api.models import UuidAuditedModel
+from api.exceptions import DeisException, AlreadyExists
 from scheduler import KubeHTTPException
 
 logger = logging.getLogger(__name__)
@@ -423,5 +424,7 @@ class Release(UuidAuditedModel):
                 if self.version == 1:
                     self.summary = "{} created the initial release".format(self.owner)
                 else:
-                    self.summary = "{} changed nothing".format(self.owner)
+                    # There were no changes to this release
+                    raise AlreadyExists("{} changed nothing - release stopped".format(self.owner))
+
         super(Release, self).save(*args, **kwargs)


### PR DESCRIPTION
# Summary of Changes

This replaces logging that nothing changed for the release and still going ahead with the release. Now it is a noop operation.

# Issue(s) that this PR Closes

Fixes #321

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. `deis pull deis/example-go -a <app>
4. `deis config:set foo=bar -a <app>`
5. `deis config:set foo=bar -a <app>`

Also, please provide a description of the desired result after the tester completes the above steps.

A `409` response should be seen