### PR TITLE
feat(release): require PORT to be set when private registry is set

### DIFF
--- a/rootfs/api/models/config.py
+++ b/rootfs/api/models/config.py
@@ -85,6 +85,13 @@ class Config(UuidAuditedModel):
         # lower case all registry options for consistency
         self.registry = {key.lower(): value for key, value in self.registry.copy().items()}
 
+        # PORT must be set if private registry is being used
+        if self.registry and self.values.get('PORT', None) is None:
+            # only thing that can get past post_save in the views
+            raise DeisException(
+                'PORT needs to be set in the config '
+                'when using a private registry')
+
     def set_tags(self, previous_config):
         """verify the tags exist on any nodes as labels"""
         if not self.tags:

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -361,11 +361,33 @@ class BuildTest(APITransactionTestCase):
         response = self.client.post(url, {'image': image})
         self.assertEqual(response.status_code, 201, response.data)
 
+        # add the required PORT information
+        url = '/v2/apps/test/config'
+        body = {'values': json.dumps({'PORT': '80'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
         # set some registry information
         url = '/v2/apps/test/config'
         body = {'registry': json.dumps({'username': 'bob', 'password': 'zoomzoom'})}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201, response.data)
+
+    def test_build_image_in_registry_with_auth_no_port(self, mock_requests):
+        """add authentication to the build but with no PORT config"""
+        self.client.post('/v2/apps', {'id': 'test'})
+
+        # post an image as a build using registry hostname
+        url = "/v2/apps/test/builds"
+        image = 'autotest/example'
+        response = self.client.post(url, {'image': image})
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # set some registry information
+        url = '/v2/apps/test/config'
+        body = {'registry': json.dumps({'username': 'bob', 'password': 'zoomzoom'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
 
     def test_release_create_failure(self, mock_requests):
         """

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -624,6 +624,18 @@ class ConfigTest(APITransactionTestCase):
         self.assertIn('registry', response.data)
         self.assertEqual(response.data['registry'], {})
 
+        # set some registry information without PORT
+        body = {'registry': json.dumps({'username': 'bob'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        registry1 = response.data
+
+        # set required PORT
+        body = {'values': json.dumps({'PORT': '80'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        registry1 = response.data
+
         # set some registry information
         body = {'registry': json.dumps({'username': 'bob'})}
         response = self.client.post(url, body)
@@ -693,7 +705,13 @@ class ConfigTest(APITransactionTestCase):
         self.assertEqual(response.status_code, 201, response.data)
         app_id = response.data['id']
 
-        # Set healthcheck URL to get defaults set
+        # Set mandatory PORT
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'PORT': '4999'})}
+        )
+
+        # Set registry information
         body = {'registry': json.dumps({
             'username': 'bob',
             'password': 's3cur3pw1'


### PR DESCRIPTION
# Summary of Changes

Prior to this the PORT was defaulting to 5000 instead.

# Issue(s) that this PR Closes

Fixes #775

# Associated End to End PR(s)

https://github.com/deis/workflow-e2e/pull/223

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

refs https://github.com/deis/workflow/pull/289

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. use `registry:set` and observe a failure
4. set `PORT`
5. Make sure `registry:set` works now
