### PR TITLE
fix(scheduler): rollback scale / deploy when the desired number of pods can not be brought up in a timely manner

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -1010,7 +1010,11 @@ class KubeHTTPClient(object):
         if waited > timeout:
             self.log(namespace, 'timed out ({}s) waiting for pods to come up in namespace {}'.format(timeout, namespace))  # noqa
 
-        self.log(namespace, "{} out of {} pods are in service".format(count, desired))  # noqa
+        self.log(namespace, "{} out of {} pods are in service".format(count, desired))
+        if count != desired:
+            # raising to allow operations to rollback
+            raise KubeException('Not enough pods in namespace {} came into service. '
+                                '{} out of {}'.format(namespace, count, desired))
 
     def _scale_rc(self, namespace, name, desired, timeout):
         rc = self.get_rc(namespace, name).json()


### PR DESCRIPTION
# Summary of Changes

Prior to this if a deploy failed at bringing up pods then it would still scale down the old release instead of rolling back. This would cause users to basically have a broken app if the new pods for whatever reason stick around in Pending mode

If the timeout period is not long enough for users then increasing the `HEALTHCHECK_INITIAL_DELAY` is the way to go.

# Issue(s) that this PR Closes

Fixes #706
Refs #785

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. `deis pull deis/example-go`
4. `deis limits:set -c cmd=2000` (this should fail)
5. `deis config:set foo=bar` (this should succeed)
6. `deis limits` (this should show Unlimited and not 2000`

Also, please provide a description of the desired result after the tester completes the above steps.

1. The app called "abcd" should be deployed
2. `k get po --namespace <app>` should still show v2 and not v3
3. Log should contain the following:
```
INFO waited 110s and 0 pods are in service
INFO waited 120s and 0 pods are in service
INFO 0 out of 1 pods in namespace quartz-zoologer are in service
INFO Not scaling RC quartz-zoologer-v3-cmd in Namespace quartz-zoologer to 0 replicas. Already at desired replicas
INFO Not scaling RC quartz-zoologer-v2-cmd in Namespace quartz-zoologer to 1 replicas. Already at desired replicas
ERROR [quartz-zoologer]: quartz-zoologer-v3-cmd (app::deploy): Could not scale quartz-zoologer-v3-cmd to 1. Deleting and going back to old release
10.244.1.10 "POST /v2/apps/quartz-zoologer/config/ HTTP/1.1" 400 134 "Deis Client v2.0.0-dev"
```

While it doesn't show the Exception message that I added in this PR it is one of the higher level messages in the `scheduler::deploy`, and the application is not town down
