### PR TITLE
ref(gunicorn): use gaiohttp workers

### DIFF
--- a/rootfs/deis/gunicorn/config.py
+++ b/rootfs/deis/gunicorn/config.py
@@ -11,7 +11,7 @@ try:
         raise ValueError()
 except (NameError, ValueError):
     workers = (os.cpu_count() or 4) * 2 + 1
-
+worker_class = 'gaiohttp'
 pythonpath = dirname(dirname(dirname(realpath(__file__))))
 timeout = 1200
 pidfile = '/tmp/gunicorn.pid'

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,4 +1,5 @@
 # Deis controller requirements
+aiohttp==0.21.6
 backoff==1.2.1
 Django==1.9.7
 django-cors-headers==1.1.0


### PR DESCRIPTION
# Summary of Changes

Replaces the default `sync` [gunicorn worker class](http://docs.gunicorn.org/en/latest/settings.html#worker-class) with `gaiohttp`. This [async worker](http://docs.gunicorn.org/en/latest/design.html#asyncio-workers) class is based on `aiohttp` for Python 3. It may offer better responsiveness and lower CPU load.

My preliminary testing shows it holds up well and uses less CPU, but I'll produce more specific benchmark results to justify this soon.

TODO:
- [ ] produce more specific benchmark results
- [x] continue long-term testing to reassure myself about stability of this change

# Testing Instructions

There are no specific testing instructions, since this should be an invisible backend change. However, monitoring for response times and CPU load over a long period of time would assure this does not introduce new problems.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom:

