### PR TITLE
fix(scheduler): make deploy have 0 replicas by default and then use scaling to go up

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -359,7 +359,10 @@ class KubeHTTPClient(object):
             logger.info('RC {} already exists under Namespace {}. Stopping deploy'.format(name, namespace))  # noqa
             return
         except KubeHTTPException:
-            new_rc = self._create_rc(namespace, name, image, command, **kwargs).json()
+            # make replicas 0 so scaling handles the work
+            replicas = kwargs.pop('replicas')
+            new_rc = self._create_rc(namespace, name, image, command, replicas=0, **kwargs).json()
+            kwargs['replicas'] = replicas
 
         # Get the desired number to scale to
         if old_rc:


### PR DESCRIPTION
# Summary of Changes

https://github.com/deis/controller/pull/790 changed the nature of how scaling works (for the better) but it had the side effect of relying on `spec/replicas` to not be set to the desired value off the bat.

In the past deploys always started at 0 and incremented up but ultimately that caused issues due to hardcoding and so it was changed so RCs would be created with the *initial* value set properly.

That didn't really gel well with #790 as it was doing a `desired == current` (desired being 1 and current being `spec/replicas`) which means `_scale_rc` was never waiting for the initial `cmd/web` Pod to come up

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. `deis pull deis/example-go`
4. Make sure the pull waits until the pod is ready
5. run `deis limits:set -c cmd=2001` (will cause the deploy to take forever, it it doesn't there is a bug)