### PR TITLE
ref(Dockerfile): only trigger package installation if requirement.txt changes

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -7,7 +7,7 @@ RUN adduser --system \
 	--group \
 	deis
 
-COPY . /app
+COPY requirements.txt /app/requirements.txt
 
 RUN buildDeps='gcc git libffi-dev libpq-dev python3-dev'; \
 	apt-get update && \
@@ -16,13 +16,15 @@ RUN buildDeps='gcc git libffi-dev libpq-dev python3-dev'; \
         libpq5 \
         python3 \
         sudo && \
-	ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
 	curl -sSL https://bootstrap.pypa.io/get-pip.py | python - pip==8.1.2 && \
 	mkdir -p /configs && chown -R deis:deis /configs && \
 	pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt && \
 	apt-get purge -y --auto-remove $buildDeps && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
+
+COPY . /app
 
 # define execution environment
 WORKDIR /app


### PR DESCRIPTION
Copying of code is done as a separate step so that the cache on that can be busted

This speeds up development *a lot*

Fixes #303

```
make deploy
docker build --rm -t quay.io/helgi/controller:git-89f49a6 rootfs
Sending build context to Docker daemon 324.1 kB
Step 1 : FROM quay.io/deis/base:0.3.0
 ---> 4d150961c772
Step 2 : RUN adduser --system 	--shell /bin/bash 	--disabled-password 	--home /app 	--group 	deis
 ---> Using cache
 ---> ee8f8856b909
Step 3 : COPY requirements.txt /app/requirements.txt
 ---> Using cache
 ---> 1cd091f64c74
Step 4 : RUN buildDeps='gcc git libffi-dev libpq-dev python3-dev'; 	apt-get update && 	apt-get install -y --no-install-recommends         $buildDeps         libpq5         python3         libpython3.5-dev         sudo &&   ln -s /usr/bin/python3 /usr/bin/python && 	curl -sSL https://bootstrap.pypa.io/get-pip.py | python - pip==8.1.2 && 	mkdir -p /configs && chown -R deis:deis /configs && 	pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt && 	apt-get purge -y --auto-remove $buildDeps && 	apt-get clean && 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
 ---> Using cache
 ---> 627cfd200bea
Step 5 : COPY . /app
 ---> Using cache
 ---> f5a8186476b5
Step 6 : WORKDIR /app
 ---> Using cache
 ---> b4a9bc4f1118
Step 7 : CMD /app/bin/boot
 ---> Using cache
 ---> f54ca709775d
Step 8 : EXPOSE 8000
 ---> Using cache
 ---> af019053fe5f
Step 9 : ENV WORKFLOW_RELEASE 2.0.0
 ---> Using cache
 ---> daaae3c22809
Successfully built daaae3c22809
docker tag -f quay.io/helgi/controller:git-89f49a6 quay.io/helgi/controller:canary
docker push quay.io/helgi/controller:canary
The push refers to a repository [quay.io/helgi/controller]
e04686fb0088: Layer already exists
014cb0b3b2ab: Layer already exists
f22c8f9d34ed: Layer already exists
1419f8ceeb99: Layer already exists
f7e7f3d0c903: Layer already exists
5f70bf18a086: Layer already exists
f34e865127cf: Layer already exists
canary: digest: sha256:32c063eab0debfea7959e67e401bee21b3bfa9660fc3e4788073391fa027fd10 size: 7933
docker push quay.io/helgi/controller:git-89f49a6
gThe push refers to a repository [quay.io/helgi/controller]
e04686fb0088: Layer already exists
014cb0b3b2ab: Layer already exists
f22c8f9d34ed: Layer already exists
1419f8ceeb99: Layer already exists
f7e7f3d0c903: Layer already exists
5f70bf18a086: Layer already exists
f34e865127cf: Layer already exists
```