### PR TITLE
fix(boot): change group ownership of docker socket

### DIFF
--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -16,6 +16,9 @@ python --version
 mkdir -p /app/data/logs
 chmod -R 777 /app/data/logs
 
+# HACK(bacongobbler): explicitly add the docker socket to the deis group
+chgrp deis /var/run/docker.sock
+
 # allow deis user group permission to Docker socket
 groupadd -g "$(stat -c "%g" /var/run/docker.sock)" docker || true
 usermod -a -G docker deis || true


### PR DESCRIPTION
# Summary of Changes

on some providers, the docker socket is owned by the root group. We want it to be owned by docker
so the controller can connect to the socket.

# Issue(s) that this PR Closes

closes #801 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

N/A since this occurs only on vagrant

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

N/A

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

N/A

# Testing Instructions

1. Create a Deis Cluster on Vagrant using kube-up.sh
2. Register an app
3. Deploy an app using `deis pull`

Results:

1. The app called "abcd" should be deployed.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: