### PR TITLE
fix(secrets): update env secrets if they already exists (overwrites existing values)

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -657,6 +657,8 @@ class KubeHTTPClient(object):
                     'type': 'env'
                 }
                 self._create_secret(namespace, secret_name, secrets_env, labels=labels)
+            else:
+                self._update_secret(namespace, secret_name, secrets_env)
 
             for key in env.keys():
                 item = {


### PR DESCRIPTION
In some cases when a release is cleaned up an orphaned secret env is left behind. This will overwrite any orphaned ones.

I will look into the cleanup logic to also delete the env secret in a follow up PR but this makes other PRs I have going on work and is far quicker.