### PR TITLE
fix(serializer): skip None values in config and registry

### DIFF
--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -135,6 +135,9 @@ class ConfigSerializer(serializers.ModelSerializer):
 
     def validate_values(self, data):
         for key, value in data.items():
+            if value is None:  # use NoneType to unset an item
+                continue
+
             if not re.match(CONFIGKEY_MATCH, key):
                 raise serializers.ValidationError(
                     "Config keys must start with a letter or underscore and "
@@ -239,6 +242,9 @@ class ConfigSerializer(serializers.ModelSerializer):
 
     def validate_registry(self, data):
         for key, value in data.items():
+            if value is None:  # use NoneType to unset an item
+                continue
+
             if not re.match(CONFIGKEY_MATCH, key):
                 raise serializers.ValidationError(
                     "Config keys must start with a letter or underscore and "

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -106,6 +106,17 @@ class ConfigTest(APITransactionTestCase):
         self.assertEqual(response.status_code, 201, response.data)
         self.assertNotIn('NEW_URL1', json.dumps(response.data['values']))
 
+        # set a port and then unset it to make sure validation ignores the unset
+        body = {'values': json.dumps({'PORT': '5000'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('PORT', response.data['values'])
+
+        body = {'values': json.dumps({'PORT': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertNotIn('PORT', response.data['values'])
+
         # disallow put/patch/delete
         response = self.client.put(url)
         self.assertEqual(response.status_code, 405, response.data)


### PR DESCRIPTION
Other config items use this and there was a probelm where config:unset was getting caught on trying to validate that PORT was numeric