### PR TITLE
ref(scheduler): move scheduler templates from JSON to YAML

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -12,7 +12,7 @@ ndg-httpsclient==0.4.0
 psycopg2==2.6.1
 pyOpenSSL==16.0.0
 pytz==2016.4
-PyYAML==3.11
+ruamel.yaml==0.11.11
 requests==2.10.0
 requests-toolbelt==0.6.2
 simpleflock==0.0.3


### PR DESCRIPTION
Reasoning behind this is everyone looks at k8s information via YAML. It is much easier to read

Uses https://yaml.readthedocs.io/en/latest/index.html instead of PyYAML as it is basing off it anyway

Decided not to change the `string.Template` approach, yet.