### PR TITLE
fix(config): return a 422 if unsetting a config key that does not exist

### DIFF
--- a/rootfs/api/exceptions.py
+++ b/rootfs/api/exceptions.py
@@ -18,6 +18,10 @@ class AlreadyExists(APIException):
     status_code = 409
 
 
+class UnprocessableEntity(APIException):
+    status_code = 422
+
+
 class ServiceUnavailable(APIException):
     status_code = 503
     default_detail = 'Service temporarily unavailable, try again later.'

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -333,3 +333,19 @@ class ReleaseTest(APITransactionTestCase):
                 body = {'version': 2}
                 response = self.client.post(url, body)
                 self.assertEqual(response.status_code, 400, response.data)
+
+    def test_release_unset_config(self, mock_requests):
+        """
+        Test that a release is created when an app is created, a config can be
+        set and then unset without causing a 409 (conflict)
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check that updating config rolls a new release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'cpu': json.dumps({'cmd': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 422, response.data)


### PR DESCRIPTION
http://www.bennadel.com/blog/2434-http-status-codes-for-invalid-data-400-vs-422.htm is a good explanation of the differences between 400 and 422 and why I picked 422

Requires https://github.com/deis/workflow-e2e/pull/236