### PR TITLE
ref(gunicorn/config.py): double default worker count

### DIFF
--- a/rootfs/deis/gunicorn/config.py
+++ b/rootfs/deis/gunicorn/config.py
@@ -10,7 +10,7 @@ try:
     if workers < 1:
         raise ValueError()
 except (NameError, ValueError):
-    workers = (os.cpu_count() or 4) * 2 + 1
+    workers = (os.cpu_count() or 4) * 4 + 1
 
 pythonpath = dirname(dirname(dirname(realpath(__file__))))
 timeout = 1200


### PR DESCRIPTION
# Summary of Changes

Doubles the default value for gunicorn workers, which increases responsiveness to a point where e2e tests seem to pass reliably with `GINKGO_NODES=30`, at the cost of more memory.

See http://docs.gunicorn.org/en/stable/design.html#how-many-workers and http://docs.gunicorn.org/en/stable/settings.html#workers.

# Issue(s) that this PR Closes

Refs deis/workflow-e2e#215.
Replaces #835.

# Pull Request Hygiene TODOs

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: