### PR TITLE
ref(gunicorn/config.py): triple default thread count

### DIFF
--- a/rootfs/deis/gunicorn/config.py
+++ b/rootfs/deis/gunicorn/config.py
@@ -11,6 +11,7 @@ try:
         raise ValueError()
 except (NameError, ValueError):
     workers = (os.cpu_count() or 4) * 2 + 1
+threads = 3
 
 pythonpath = dirname(dirname(dirname(realpath(__file__))))
 timeout = 1200


### PR DESCRIPTION
# Summary of Changes

Triples the default thread count for gunicorn workers, which increases responsiveness to a point where e2e tests seem to pass reliably with `GINKGO_NODES=30`, at the cost of slightly more memory.

See http://docs.gunicorn.org/en/stable/design.html#how-many-threads and http://docs.gunicorn.org/en/stable/settings.html#threads.

# Issue(s) that this PR Closes

Refs deis/workflow-e2e#215.
Replaces #833.

# Pull Request Hygiene TODOs

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom:

