### PR TITLE
feat(settings): log all SQL queries if DEBUG==True

### DIFF
--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -204,6 +204,12 @@ LOGGING = {
             'filters': ['require_debug_true'],
             'propagate': True,
         },
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'filters': ['require_debug_true'],
+            'propagate': False,
+        },
         'django.request': {
             'handlers': ['console'],
             'level': 'WARNING',


### PR DESCRIPTION
# Summary of Changes

Logs all SQL queries to stdout if DEBUG==True:
```
+ python /app/manage.py load_db_state_to_k8s
+ sudo -E -u deis gunicorn -c /app/deis/gunicorn/config.py api.wsgi
[2016-06-22 22:36:32 +0000] [23] [INFO] Starting gunicorn 19.6.0
[2016-06-22 22:36:32 +0000] [23] [INFO] Listening at: http://0.0.0.0:8000 (23)
[2016-06-22 22:36:32 +0000] [23] [INFO] Using worker: sync
[2016-06-22 22:36:32 +0000] [26] [INFO] Booting worker with pid: 26
[2016-06-22 22:36:32 +0000] [28] [INFO] Booting worker with pid: 28
[2016-06-22 22:36:32 +0000] [30] [INFO] Booting worker with pid: 30
[2016-06-22 22:36:32 +0000] [32] [INFO] Booting worker with pid: 32
[2016-06-22 22:36:32 +0000] [33] [INFO] Booting worker with pid: 33
DEBUG (0.001) SELECT "api_key"."uuid", "api_key"."created", "api_key"."updated", "api_key"."owner_id", "api_key"."id", "api_key"."public", "api_key"."fingerprint" FROM "api_key"; args=()
DEBUG (0.001) SELECT "api_app"."uuid", "api_app"."created", "api_app"."updated", "api_app"."owner_id", "api_app"."id", "api_app"."structure" FROM "api_app"; args=()
DEBUG (0.001) SELECT "api_release"."uuid", "api_release"."created", "api_release"."updated", "api_release"."owner_id", "api_release"."app_id", "api_release"."version", "api_release"."summary", "api_release"."config_id", "api_release"."build_id" FROM "api_release" WHERE "api_release"."app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid ORDER BY "api_release"."created" DESC LIMIT 1; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG (0.001) UPDATE "api_app" SET "created" = '2016-06-22T22:23:40.868289+00:00'::timestamptz, "updated" = '2016-06-22T22:36:33.839180+00:00'::timestamptz, "owner_id" = 2, "id" = 'zircon-lungfish', "structure" = '{}' WHERE "api_app"."uuid" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid; args=(datetime.datetime(2016, 6, 22, 22, 23, 40, 868289, tzinfo=<UTC>), datetime.datetime(2016, 6, 22, 22, 36, 33, 839180, tzinfo=<UTC>), 2, 'zircon-lungfish', '{}', UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'))
DEBUG (0.001) SELECT "api_config"."uuid", "api_config"."created", "api_config"."updated", "api_config"."owner_id", "api_config"."app_id", "api_config"."values", "api_config"."memory", "api_config"."cpu", "api_config"."tags", "api_config"."registry" FROM "api_config" WHERE "api_config"."app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid ORDER BY "api_config"."created" DESC LIMIT 1; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG (0.001) SELECT "api_release"."uuid", "api_release"."created", "api_release"."updated", "api_release"."owner_id", "api_release"."app_id", "api_release"."version", "api_release"."summary", "api_release"."config_id", "api_release"."build_id" FROM "api_release" WHERE "api_release"."app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid ORDER BY "api_release"."created" DESC LIMIT 1; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG [zircon-lungfish]: creating Namespace zircon-lungfish and services
DEBUG (0.001) SELECT (1) AS "a" FROM "api_domain" WHERE "api_domain"."domain" = 'zircon-lungfish' LIMIT 1; args=('zircon-lungfish',)
DEBUG (0.003) SELECT "api_domain"."id", "api_domain"."created", "api_domain"."updated", "api_domain"."owner_id", "api_domain"."app_id", "api_domain"."domain", "api_domain"."certificate_id" FROM "api_domain"; args=()
DEBUG (0.002) SELECT "api_app"."uuid", "api_app"."created", "api_app"."updated", "api_app"."owner_id", "api_app"."id", "api_app"."structure" FROM "api_app" WHERE "api_app"."uuid" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG (0.001) UPDATE "api_domain" SET "created" = '2016-06-22T22:23:41.055749+00:00'::timestamptz, "updated" = '2016-06-22T22:36:34.015713+00:00'::timestamptz, "owner_id" = 2, "app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid, "domain" = 'zircon-lungfish', "certificate_id" = NULL WHERE "api_domain"."id" = 1; args=(datetime.datetime(2016, 6, 22, 22, 23, 41, 55749, tzinfo=<UTC>), datetime.datetime(2016, 6, 22, 22, 36, 34, 15713, tzinfo=<UTC>), 2, UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'), 'zircon-lungfish', 1)
DEBUG (0.001) SELECT "api_certificate"."id", "api_certificate"."created", "api_certificate"."updated", "api_certificate"."owner_id", "api_certificate"."name", "api_certificate"."certificate", "api_certificate"."key", "api_certificate"."common_name", "api_certificate"."san", "api_certificate"."fingerprint", "api_certificate"."expires", "api_certificate"."starts", "api_certificate"."issuer", "api_certificate"."subject" FROM "api_certificate"; args=()
DEBUG (0.001) SELECT "api_config"."uuid", "api_config"."created", "api_config"."updated", "api_config"."owner_id", "api_config"."app_id", "api_config"."values", "api_config"."memory", "api_config"."cpu", "api_config"."tags", "api_config"."registry" FROM "api_config" ORDER BY "api_config"."created" DESC; args=()
DEBUG (0.000) SELECT "api_app"."uuid", "api_app"."created", "api_app"."updated", "api_app"."owner_id", "api_app"."id", "api_app"."structure" FROM "api_app" WHERE "api_app"."uuid" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG (0.002) SELECT "api_release"."uuid", "api_release"."created", "api_release"."updated", "api_release"."owner_id", "api_release"."app_id", "api_release"."version", "api_release"."summary", "api_release"."config_id", "api_release"."build_id" FROM "api_release" WHERE "api_release"."app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid ORDER BY "api_release"."created" DESC LIMIT 1; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
DEBUG (0.002) SELECT "api_config"."uuid", "api_config"."created", "api_config"."updated", "api_config"."owner_id", "api_config"."app_id", "api_config"."values", "api_config"."memory", "api_config"."cpu", "api_config"."tags", "api_config"."registry" FROM "api_config" WHERE "api_config"."uuid" = '6da86550-ff79-4665-9a01-a906ff87974c'::uuid; args=(UUID('6da86550-ff79-4665-9a01-a906ff87974c'),)
DEBUG (0.007) UPDATE "api_config" SET "created" = '2016-06-22T22:23:40.877823+00:00'::timestamptz, "updated" = '2016-06-22T22:36:34.033122+00:00'::timestamptz, "owner_id" = 2, "app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid, "values" = '{}', "memory" = '{}', "cpu" = '{}', "tags" = '{}', "registry" = '{}' WHERE "api_config"."uuid" = '6da86550-ff79-4665-9a01-a906ff87974c'::uuid; args=(datetime.datetime(2016, 6, 22, 22, 23, 40, 877823, tzinfo=<UTC>), datetime.datetime(2016, 6, 22, 22, 36, 34, 33122, tzinfo=<UTC>), 2, UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'), '{}', '{}', '{}', '{}', '{}', UUID('6da86550-ff79-4665-9a01-a906ff87974c'))
INFO [zircon-lungfish]: config zircon-lungfish-6da8655 updated
DEBUG (0.000) SELECT "api_certificate"."id", "api_certificate"."created", "api_certificate"."updated", "api_certificate"."owner_id", "api_certificate"."name", "api_certificate"."certificate", "api_certificate"."key", "api_certificate"."common_name", "api_certificate"."san", "api_certificate"."fingerprint", "api_certificate"."expires", "api_certificate"."starts", "api_certificate"."issuer", "api_certificate"."subject" FROM "api_certificate"; args=()
DEBUG (0.000) SELECT "api_app"."uuid", "api_app"."created", "api_app"."updated", "api_app"."owner_id", "api_app"."id", "api_app"."structure" FROM "api_app"; args=()
DEBUG (0.002) SELECT "api_release"."uuid", "api_release"."created", "api_release"."updated", "api_release"."owner_id", "api_release"."app_id", "api_release"."version", "api_release"."summary", "api_release"."config_id", "api_release"."build_id" FROM "api_release" WHERE "api_release"."app_id" = '982c5aa1-0d7e-46ab-af82-c14e3676ca5c'::uuid ORDER BY "api_release"."created" DESC LIMIT 1; args=(UUID('982c5aa1-0d7e-46ab-af82-c14e3676ca5c'),)
Publishing DB state to kubernetes...
Deploying available applications
WARNING: zircon-lungfish has no build associated with its latest release. Skipping deployment...
Done Publishing DB state to kubernetes.
+ trap on_exit TERM
+ echo deis-controller running...
+ wait
deis-controller running...
```

I have found this extremely helpful when debugging.

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Deploy a Deis cluster with `DEIS_DEBUG: "true"`
2. Tail the controller logs and see that SQL queries are logged

# Pull Request Hygiene TODOs

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

:cherry_blossom: Thank you! :cherry_blossom: