### PR TITLE
fix(passwd): raise 400 when password is not a parameter

### DIFF
--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -258,10 +258,20 @@ class AuthTest(DeisTestCase):
         url = '/v2/auth/register'
         response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201, response.data)
-        # change password
+        # change password without new password
         url = '/v2/auth/passwd'
         user = User.objects.get(username=username)
         token = Token.objects.get(user=user).key
+        response = self.client.post(url, {},
+                                    HTTP_AUTHORIZATION='token {}'.format(token))
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'new_password is a required field'})
+        # change password without password field
+        response = self.client.post(url, {'new_password': 'test'},
+                                    HTTP_AUTHORIZATION='token {}'.format(token))
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'password is a required field'})
+        # change password
         submit = {
             'password': 'password2',
             'new_password': password,

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -93,6 +93,9 @@ class UserManagementViewSet(GenericViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def passwd(self, request, **kwargs):
+        if not request.data.get('new_password'):
+            raise DeisException("new_password is a required field")
+
         caller_obj = self.get_object()
         target_obj = self.get_object()
         if request.data.get('username'):
@@ -102,7 +105,9 @@ class UserManagementViewSet(GenericViewSet):
             else:
                 raise PermissionDenied()
 
-        if request.data.get('password') or not caller_obj.is_superuser:
+        if not caller_obj.is_superuser:
+            if not request.data.get('password'):
+                raise DeisException("password is a required field")
             if not target_obj.check_password(request.data['password']):
                 raise AuthenticationFailed('Current password does not match')
 


### PR DESCRIPTION
# Summary of Changes

Previously, passwd didn't check if `password` or `new_password` was set resulting in server errors when trying to access them.
I haven't wrote any tests, cause I wanted to make sure this was the right approach.
I was also looking at serializers, but it doesn't seem like you can override the serializers on a per-view basis. I'm also concerned about using a `DeisException`, because I would rather have a field specific error, like serializers do.

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a normal user.
2. Try `POST /v2/auth/passwd` without `new_password` or `password` and make sure 500 errors are returned.

