### PR TITLE
feat(IDN): add support for international domains

### DIFF
--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -291,7 +291,17 @@ class DomainViewSet(AppResourceViewSet):
 
     def get_object(self, **kwargs):
         qs = self.get_queryset(**kwargs)
-        return get_object_or_404(qs, domain=self.kwargs['domain'])
+        domain = self.kwargs['domain']
+        # support IDN domains, i.e. accept Unicode encoding too
+        try:
+            import idna
+            if domain.startswith("*."):
+                ace_domain = "*." + idna.encode(domain[2:]).decode("utf-8", "strict")
+            else:
+                ace_domain = idna.encode(domain).decode("utf-8", "strict")
+        except:
+            ace_domain = domain
+        return get_object_or_404(qs, domain=ace_domain)
 
 
 class CertificateViewSet(BaseDeisViewSet):

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -17,3 +17,4 @@ requests==2.10.0
 requests-toolbelt==0.6.2
 simpleflock==0.0.3
 jsonschema==2.5.1
+idna==2.1


### PR DESCRIPTION
Hi, I have rewritten the validation code of `DomainSerializer ` to support IDN domains.
If a Unicode domain is added to an app, it is stored in ASCII compatible encoding (ACE).
Adjusted `DomainViewSet` so it maps Unicode input to ACE.
Created test `test_manage_idn_domain`, modified tested domains for `test_manage_domain` and `test_manage_domain_invalid_domain` to reflect the changes regaring IDN support.
Adds [python package idna](https://pypi.python.org/pypi/idna) as new dependency to the project.

closes #318

See also https://github.com/deis/router/commit/76ea246732f6987951913877a7d0a24ed0619c9c, I am going add a PR for this commit too.