### PR TITLE
feat(scheduler): add support for set based requirement filtering via the kubernetes API

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -258,9 +258,7 @@ class Release(UuidAuditedModel):
         )
 
         # Cleanup controllers
-        labels = {
-            'heritage': 'deis'
-        }
+        labels = {'heritage': 'deis'}
         controller_removal = []
         controllers = self._scheduler.get_rcs(self.app.id, labels=labels).json()
         for controller in controllers['items']:
@@ -299,9 +297,7 @@ class Release(UuidAuditedModel):
             self._scheduler.delete_secret(self.app.id, secret['metadata']['name'])
 
         # Remove stray pods
-        labels = {
-            'heritage': 'deis'
-        }
+        labels = {'heritage': 'deis'}
         pods = self._scheduler.get_pods(self.app.id, labels=labels).json()
         for pod in pods['items']:
             if self._scheduler.pod_deleted(pod):


### PR DESCRIPTION
Makes it possible to use a `notin()` and `in()` filter.

This can be achieved by using this syntax: `version__notin(v3, v4, v5)` or `type__in(cmd, web, public)`

set based filtering makes it easy to exclude the latest version of a resource (based on a deis version). It is possible to combine filters as well