### PR TITLE
feat(*): add Deployments support behind a feature flag

### DIFF
--- a/rootfs/api/exceptions.py
+++ b/rootfs/api/exceptions.py
@@ -39,7 +39,7 @@ def custom_exception_handler(exc, context):
         set_rollback()
         return Response({'detail': 'Server Error'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    # log a few different types of exception instead of use APIException
+    # log a few different types of exception instead of using APIException
     if isinstance(exc, (DeisException, ServiceUnavailable, HealthcheckException)):
         logging.exception(exc.__cause__, exc_info=exc)
 

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -265,6 +265,11 @@ DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POL
 # Can also be overwritten on per app basis if desired
 DEIS_DEPLOY_BATCHES = os.environ.get('DEIS_DEPLOY_BATCHES', None)
 
+# If the k8s Deployments object should be used instead of ReplicationController
+DEIS_KUBERNETES_DEPLOYMENTS = bool(os.environ.get('DEIS_KUBERNETES_DEPLOYMENTS', False))
+
+KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT = os.environ.get('KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT', None)  # noqa
+
 # How long k8s waits for a pod to finish work after a SIGTERM before sending SIGKILL
 KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS = int(os.environ.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', 30))  # noqa
 

--- a/rootfs/api/tests/deployments/test_app.py
+++ b/rootfs/api/tests/deployments/test_app.py
@@ -1,0 +1,533 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+import logging
+from unittest import mock
+import requests
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App
+from scheduler import KubeException
+
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+
+def mock_none(*args, **kwargs):
+    return None
+
+
+def _mock_run(*args, **kwargs):
+    return [0, 'mock']
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class AppTest(APITestCase):
+    """Tests creation of applications"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_app(self, mock_requests):
+        """
+        Test that a user can create, read, update and delete an application
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']  # noqa
+        self.assertIn('id', response.data)
+        response = self.client.get('/v2/apps')
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        url = '/v2/apps/{app_id}'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        body = {'id': 'new'}
+        response = self.client.patch(url, body)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+
+    def test_response_data(self, mock_requests):
+        """Test that the serialized response contains only relevant data."""
+        body = {'id': 'test'}
+        response = self.client.post('/v2/apps', body)
+        for key in response.data:
+            self.assertIn(key, ['uuid', 'created', 'updated', 'id', 'owner', 'structure'])
+        expected = {
+            'id': 'test',
+            'owner': self.user.username,
+            'structure': {}
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+    def test_app_override_id(self, mock_requests):
+        body = {'id': 'myid'}
+        response = self.client.post('/v2/apps', body)
+        self.assertEqual(response.status_code, 201, response.data)
+        body = {'id': response.data['id']}
+        response = self.client.post('/v2/apps', body)
+        self.assertContains(response, 'App with this id already exists.', status_code=400)
+        return response
+
+    @mock.patch('requests.get')
+    def test_app_actions(self, mock_requests, mock_get):
+        url = '/v2/apps'
+        body = {'id': 'autotest'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']  # noqa
+
+        # test logs - 204 from deis-logger
+        mock_response = mock.Mock()
+        mock_response.status_code = 204
+        mock_get.return_value = mock_response
+        url = "/v2/apps/{app_id}/logs".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 204, response.content)
+
+        # test logs - 404 from deis-logger
+        mock_response.status_code = 404
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 204, response.content)
+
+        # test logs - unanticipated status code from deis-logger
+        mock_response.status_code = 400
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            "Error accessing logs for {}".format(app_id),
+            status_code=500)
+
+        # test logs - success accessing deis-logger
+        mock_response.status_code = 200
+        mock_response.content = FAKE_LOG_DATA
+        response = self.client.get(url)
+        self.assertContains(response, FAKE_LOG_DATA, status_code=200)
+
+        # test logs - HTTP request error while accessing deis-logger
+        mock_get.side_effect = requests.exceptions.RequestException('Boom!')
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            "Error accessing logs for {}".format(app_id),
+            status_code=500)
+
+        # TODO: test run needs an initial build
+
+    @mock.patch('api.models.logger')
+    def test_app_release_notes_in_logs(self, mock_requests, mock_logger):
+        """Verifies that an app's release summary is dumped into the logs."""
+        url = '/v2/apps'
+        body = {'id': 'autotest'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        # check app logs
+        exp_msg = "autotest created initial release"
+        exp_log_call = mock.call(logging.INFO, exp_msg)
+        mock_logger.log.has_calls(exp_log_call)
+
+    def test_app_errors(self, mock_requests):
+        app_id = 'autotest-errors'
+        url = '/v2/apps'
+        body = {'id': 'camelCase'}
+        response = self.client.post(url, body)
+        self.assertContains(
+            response,
+            'App name can only contain a-z (lowercase), 0-9 and hyphens',
+            status_code=400
+        )
+        url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']  # noqa
+        url = '/v2/apps/{app_id}'.format(**locals())
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+        for endpoint in ('containers', 'config', 'releases', 'builds'):
+            url = '/v2/apps/{app_id}/{endpoint}'.format(**locals())
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
+
+    def test_app_reserved_names(self, mock_requests):
+        """Nobody should be able to create applications with names which are reserved."""
+        url = '/v2/apps'
+        reserved_names = ['foo', 'bar']
+        with self.settings(DEIS_RESERVED_NAMES=reserved_names):
+            for name in reserved_names:
+                body = {'id': name}
+                response = self.client.post(url, body)
+                self.assertContains(
+                    response,
+                    '{} is a reserved name.'.format(name),
+                    status_code=400)
+
+    def test_app_structure_is_valid_json(self, mock_requests):
+        """Application structures should be valid JSON objects."""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        self.assertIn('structure', response.data)
+        self.assertEqual(response.data['structure'], {})
+        app = App.objects.get(id=app_id)
+        app.structure = {'web': 1}
+        app.save()
+        url = '/v2/apps/{}'.format(app_id)
+        response = self.client.get(url)
+        self.assertIn('structure', response.data)
+        self.assertEqual(response.data['structure'], {"web": 1})
+
+    @mock.patch('api.models.logger')
+    def test_admin_can_manage_other_apps(self, mock_requests, mock_logger):
+        """Administrators of Deis should be able to manage all applications.
+        """
+        # log in as non-admin user and create an app
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        app_id = 'autotest'
+        url = '/v2/apps'
+        body = {'id': app_id}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url, body)
+
+        # log in as admin, check to see if they have access
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        url = '/v2/apps/{}'.format(app_id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        # check app logs
+        exp_msg = "autotest2 created initial release"
+        exp_log_call = mock.call(logging.INFO, exp_msg)
+        mock_logger.log.has_calls(exp_log_call)
+
+        # TODO: test run needs an initial build
+        # delete the app
+        url = '/v2/apps/{}'.format(app_id)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+
+    def test_admin_can_see_other_apps(self, mock_requests):
+        """If a user creates an application, the administrator should be able
+        to see it.
+        """
+        # log in as non-admin user and create an app
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        app_id = 'autotest'
+        url = '/v2/apps'
+        body = {'id': app_id}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url, body)
+
+        # log in as admin
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url)
+        self.assertEqual(response.data['count'], 1)
+
+    def test_run_without_release_should_error(self, mock_requests):
+        """
+        A user should not be able to run a one-off command unless a release
+        is present.
+        """
+        app_id = 'autotest'
+        url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(url, body)
+        url = '/v2/apps/{}/run'.format(app_id)
+        body = {'command': 'ls -al'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'No build associated with this '
+                                                   'release to run this command'})
+
+    @mock.patch('api.models.App.run', _mock_run)
+    @mock.patch('api.models.App.deploy', mock_none)
+    @mock.patch('api.models.Release.publish', mock_none)
+    def test_run(self, mock_requests):
+        """
+        A user should be able to run a one off command
+        """
+        app_id = 'autotest'
+        response = self.client.post('/v2/apps', {'id': app_id})
+
+        # create build
+        body = {'image': 'autotest/example'}
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # run command
+        url = '/v2/apps/{}/run'.format(app_id)
+        body = {'command': 'ls -al'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['exit_code'], 0)
+        self.assertEqual(response.data['output'], 'mock')
+
+    def test_run_failure(self, mock_requests):
+        """Raise a KubeException via scheduler.run"""
+        app_id = 'autotest'
+        response = self.client.post('/v2/apps', {'id': app_id})
+
+        # create build
+        body = {'image': 'autotest/example'}
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        with mock.patch('scheduler.KubeHTTPClient.run') as kube_run:
+            kube_run.side_effect = KubeException('boom!')
+            # run command
+            url = '/v2/apps/{}/run'.format(app_id)
+            body = {'command': 'ls -al'}
+            response = self.client.post(url, body)
+            self.assertEqual(response.status_code, 503, response.data)
+
+    def test_unauthorized_user_cannot_see_app(self, mock_requests):
+        """
+        An unauthorized user should not be able to access an app's resources.
+
+        Since an unauthorized user can't access the application, these
+        tests should return a 403, but currently return a 404. FIXME!
+        """
+        app_id = 'autotest'
+        base_url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(base_url, body)
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+
+        url = '{}/{}/run'.format(base_url, app_id)
+        body = {'command': 'foo'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+
+        url = '{}/{}/logs'.format(base_url, app_id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        url = '{}/{}'.format(base_url, app_id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_app_info_not_showing_wrong_app(self, mock_requests):
+        app_id = 'autotest'
+        base_url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(base_url, body)
+        url = '{}/foo'.format(base_url)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_app_transfer(self, mock_requests):
+        owner = User.objects.get(username='autotest2')
+        owner_token = Token.objects.get(user=owner).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
+
+        app_id = 'autotest'
+        base_url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(base_url, body)
+
+        # Transfer App
+        url = '{}/{}'.format(base_url, app_id)
+        new_owner = User.objects.get(username='autotest3')
+        new_owner_token = Token.objects.get(user=new_owner).key
+        body = {'owner': new_owner.username}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        # Original user can no longer access it
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        # New owner can access it
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + new_owner_token)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['owner'], new_owner.username)
+
+        # Collaborators can't transfer
+        body = {'username': owner.username}
+        perms_url = url+"/perms/"
+        response = self.client.post(perms_url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + owner_token)
+        body = {'owner': self.user.username}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+
+        # Admins can transfer
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        body = {'owner': self.user.username}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['owner'], self.user.username)
+
+    def test_app_exists_in_kubernetes(self, mock_requests):
+        """
+        Create an app that has the same namespace as an existing kubernetes namespace
+        """
+        body = {'id': 'duplicate'}
+        response = self.client.post('/v2/apps', body)
+        self.assertContains(
+            response,
+            'duplicate already exists as a namespace in this kuberenetes setup',
+            status_code=409
+        )
+
+    def test_app_create_failure_kubernetes_create(self, mock_requests):
+        """
+        Create an app but have scheduler.create_service fail with an exception
+        """
+        with mock.patch('scheduler.KubeHTTPClient.create_service') as mock_kube:
+            mock_kube.side_effect = KubeException('Boom!')
+            response = self.client.post('/v2/apps', {'id': 'test-kube'})
+            self.assertEqual(response.status_code, 503, response.data)
+
+    def test_app_delete_failure_kubernetes_destroy(self, mock_requests):
+        """
+        Create an app and then delete but have scheduler.delete_namespace
+        fail with an exception
+        """
+        # create
+        response = self.client.post('/v2/apps', {'id': 'test'})
+        self.assertEqual(response.status_code, 201, response.data)
+
+        with mock.patch('scheduler.KubeHTTPClient.delete_namespace') as mock_kube:
+            # delete
+            mock_kube.side_effect = KubeException('Boom!')
+            response = self.client.delete('/v2/apps/test')
+            self.assertEqual(response.status_code, 503, response.data)
+
+    def test_app_verify_application_health_success(self, mock_requests):
+        """
+        Create an application which in turn causes a health check to run against
+        the router. Make it succeed on the 6th try
+        """
+        responses = [
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'OK', 'status_code': 200}
+        ]
+        hostname = 'http://{}:{}/'.format(settings.ROUTER_HOST, settings.ROUTER_PORT)
+        mr = mock_requests.register_uri('GET', hostname, responses)
+
+        # create app
+        body = {'id': 'myid'}
+        response = self.client.post('/v2/apps', body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # deploy app to get verification
+        url = "/v2/apps/myid/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        self.assertEqual(mr.called, True)
+        self.assertEqual(mr.call_count, 6)
+
+    def test_app_verify_application_health_failure_404(self, mock_requests):
+        """
+        Create an application which in turn causes a health check to run against
+        the router. Make it fail with a 404 after 10 tries
+        """
+        # function tries to hit router 10 times
+        responses = [
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+            {'text': 'Not Found', 'status_code': 404},
+        ]
+        hostname = 'http://{}:{}/'.format(settings.ROUTER_HOST, settings.ROUTER_PORT)
+        mr = mock_requests.register_uri('GET', hostname, responses)
+
+        # create app
+        body = {'id': 'myid'}
+        response = self.client.post('/v2/apps', body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # deploy app to get verification
+        url = "/v2/apps/myid/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        self.assertEqual(mr.called, True)
+        self.assertEqual(mr.call_count, 10)
+
+    def test_app_verify_application_health_failure_exceptions(self, mock_requests):
+        """
+        Create an application which in turn causes a health check to run against
+        the router. Make it fail with a python-requets exception
+        """
+        def _raise_exception(request, ctx):
+            raise requests.exceptions.RequestException('Boom!')
+
+        # function tries to hit router 10 times
+        hostname = 'http://{}:{}/'.format(settings.ROUTER_HOST, settings.ROUTER_PORT)
+        mr = mock_requests.register_uri('GET', hostname, text=_raise_exception)
+
+        # create app
+        body = {'id': 'myid'}
+        response = self.client.post('/v2/apps', body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # deploy app to get verification
+        url = "/v2/apps/myid/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        # Called 10 times due to the exception
+        self.assertEqual(mr.called, True)
+        self.assertEqual(mr.call_count, 10)
+
+FAKE_LOG_DATA = """
+2013-08-15 12:41:25 [33454] [INFO] Starting gunicorn 17.5
+2013-08-15 12:41:25 [33454] [INFO] Listening at: http://0.0.0.0:5000 (33454)
+2013-08-15 12:41:25 [33454] [INFO] Using worker: sync
+2013-08-15 12:41:25 [33457] [INFO] Booting worker with pid 33457
+"""

--- a/rootfs/api/tests/deployments/test_build.py
+++ b/rootfs/api/tests/deployments/test_build.py
@@ -1,0 +1,463 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+
+
+import json
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.conf import settings
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+from unittest import mock
+from rest_framework.authtoken.models import Token
+
+from api.models import Build
+from registry.dockerclient import RegistryException
+from scheduler import KubeException
+
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class BuildTest(APITransactionTestCase):
+
+    """Tests build notification from build system"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_build(self, mock_requests):
+        """
+        Test that a null build is created and that users can post new builds
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # check to see that no initial build was created
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['count'], 0)
+        # post a new build
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        build_id = str(response.data['uuid'])
+        build1 = response.data
+        self.assertEqual(response.data['image'], body['image'])
+        # read the build
+        url = "/v2/apps/{app_id}/builds/{build_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        build2 = response.data
+        self.assertEqual(build1, build2)
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        build3 = response.data
+        self.assertEqual(response.data['image'], body['image'])
+        self.assertNotEqual(build2['uuid'], build3['uuid'])
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_response_data(self, mock_requests):
+        """Test that the serialized response contains only relevant data."""
+        body = {'id': 'test'}
+        url = '/v2/apps'
+        response = self.client.post(url, body)
+        # post an image as a build
+        url = "/v2/apps/test/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+
+        for key in response.data:
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'dockerfile',
+                                'image', 'procfile', 'sha'])
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'dockerfile': '',
+            'image': 'autotest/example',
+            'procfile': {},
+            'sha': ''
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+    def test_build_default_containers(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # post an image as a build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'cmd')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+
+        # start with a new app
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # post a new build with procfile
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'dockerfile': "FROM scratch"
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'cmd')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+
+        # start with a new app
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build with procfile
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'dockerfile': "FROM scratch",
+            'procfile': {
+                'worker': 'node worker.js'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'cmd')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+
+        # start with a new app
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # post a new build with procfile
+
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods/web".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'web')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
+
+    def test_build_str(self, mock_requests):
+        """Test the text representation of a build."""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        build = Build.objects.get(uuid=response.data['uuid'])
+        self.assertEqual(str(build), "{}-{}".format(
+                         response.data['app'], str(response.data['uuid'])[:7]))
+
+    def test_admin_can_create_builds_on_other_apps(self, mock_requests):
+        """If a user creates an application, an administrator should be able
+        to push builds.
+        """
+        # create app as non-admin
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build as admin
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        build = Build.objects.get(uuid=response.data['uuid'])
+        self.assertEqual(str(build), "{}-{}".format(
+                         response.data['app'], str(response.data['uuid'])[:7]))
+
+    def test_unauthorized_user_cannot_modify_build(self, mock_requests):
+        """
+        An unauthorized user should not be able to modify other builds.
+
+        Since an unauthorized user can't access the application, these
+        requests should return a 403.
+        """
+        app_id = 'autotest'
+        url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(url, body)
+
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+        url = '{}/{}/builds'.format(url, app_id)
+        body = {'image': 'foo'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+
+    def test_new_build_does_not_scale_up_automatically(self, mock_requests):
+        """
+        After the first initial deploy, if the containers are scaled down to zero,
+        they should stay that way on a new release.
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods/web".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+
+        # scale to zero
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 0}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # post another build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        url = "/v2/apps/{app_id}/pods/web".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+    def test_build_image_in_registry(self, mock_requests):
+        """When the image is already in the deis registry no pull/tag/push happens"""
+        body = {'id': 'test'}
+        url = '/v2/apps'
+        response = self.client.post(url, body)
+
+        # post an image as a build using registry hostname
+        url = "/v2/apps/test/builds".format(**locals())
+        image = '{}/autotest/example'.format(settings.REGISTRY_HOST)
+        body = {'image': image}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        build = Build.objects.get(uuid=response.data['uuid'])
+        release = build.app.release_set.latest()
+        # Registry host is internally stripped off
+        self.assertEqual(release.image, 'autotest/example')
+
+        # post an image as a build using registry hostname + port
+        url = "/v2/apps/test/builds".format(**locals())
+        image = '{}/autotest/example'.format(settings.REGISTRY_URL)
+        body = {'image': image}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        build = Build.objects.get(uuid=response.data['uuid'])
+        release = build.app.release_set.latest()
+        # Registry host + port is internally stripped off
+        self.assertEqual(release.image, 'autotest/example')
+
+    def test_build_image_in_registry_with_auth(self, mock_requests):
+        """add authentication to the build"""
+        self.client.post('/v2/apps', {'id': 'test'})
+
+        # post an image as a build using registry hostname
+        url = "/v2/apps/test/builds"
+        image = 'autotest/example'
+        response = self.client.post(url, {'image': image})
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # add the required PORT information
+        url = '/v2/apps/test/config'
+        body = {'values': json.dumps({'PORT': '80'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # set some registry information
+        url = '/v2/apps/test/config'
+        body = {'registry': json.dumps({'username': 'bob', 'password': 'zoomzoom'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_build_image_in_registry_with_auth_no_port(self, mock_requests):
+        """add authentication to the build but with no PORT config"""
+        self.client.post('/v2/apps', {'id': 'test'})
+
+        # post an image as a build using registry hostname
+        url = "/v2/apps/test/builds"
+        image = 'autotest/example'
+        response = self.client.post(url, {'image': image})
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # set some registry information
+        url = '/v2/apps/test/config'
+        body = {'registry': json.dumps({'username': 'bob', 'password': 'zoomzoom'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_release_create_failure(self, mock_requests):
+        """
+        Cause an Exception in app.deploy to cause a release.delete in build.create
+        """
+        body = {'id': 'test'}
+        self.client.post('/v2/apps', body)
+
+        # deploy app to get a build
+        url = "/v2/apps/test/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        with mock.patch('api.models.App.deploy') as mock_deploy:
+            mock_deploy.side_effect = Exception('Boom!')
+
+            url = "/v2/apps/test/builds"
+            body = {'image': 'autotest/example'}
+            response = self.client.post(url, body)
+            self.assertEqual(response.status_code, 400, response.data)
+
+    def test_release_registry_create_failure(self, mock_requests):
+        """
+        Cause a RegistryException in app.deploy to cause a release.delete in build.create
+        """
+        body = {'id': 'test'}
+        self.client.post('/v2/apps', body)
+
+        # deploy app to get a build
+        url = "/v2/apps/test/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        with mock.patch('api.models.Release.publish') as mock_registry:
+            mock_registry.side_effect = RegistryException('Boom!')
+
+            url = "/v2/apps/test/builds"
+            body = {'image': 'autotest/example'}
+            response = self.client.post(url, body)
+            self.assertEqual(response.status_code, 400, response.data)
+
+    def test_build_deploy_kube_failure(self, mock_requests):
+        """
+        Cause an Exception in scheduler.deploy
+        """
+        body = {'id': 'test'}
+        self.client.post('/v2/apps', body)
+
+        with mock.patch('scheduler.KubeHTTPClient.deploy') as mock_deploy:
+            mock_deploy.side_effect = KubeException('Boom!')
+
+            url = "/v2/apps/test/builds"
+            body = {'image': 'autotest/example'}
+            response = self.client.post(url, body)
+            self.assertEqual(response.status_code, 400, response.data)

--- a/rootfs/api/tests/deployments/test_certificate.py
+++ b/rootfs/api/tests/deployments/test_certificate.py
@@ -1,0 +1,148 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from django.core.exceptions import SuspiciousOperation
+
+from api.models import App, Certificate
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateTest(APITestCase):
+
+    """Tests creation of domain SSL certificates"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app')
+        self.domain = 'autotest.example.com'
+
+        with open('{}/certs/{}.key'.format(TEST_ROOT, self.domain)) as f:
+            self.key = f.read()
+
+        with open('{}/certs/{}.cert'.format(TEST_ROOT, self.domain)) as f:
+            self.cert = f.read()
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'random-test-cert',
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_update_certificate(self):
+        """Tests update of a certificate."""
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'random-test-cert',
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_create_certificate_with_different_common_name(self):
+        """
+        Make sure common_name is read-only
+        """
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'random-test-cert',
+                'certificate': self.cert,
+                'key': self.key,
+                'common_name': 'foo.example.com'
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['common_name'], 'autotest.example.com')
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate, only the common name and expiry date should be
+        displayed.
+        """
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'random-test-cert',
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        response = self.client.get('{}/{}'.format(self.url, 'random-test-cert'))
+        self.assertEqual(response.status_code, 200, response.data)
+
+        expected = {
+            'common_name': 'autotest.example.com',
+            'expires': '2016-03-05T17:14:27Z',
+            'fingerprint': '37:24:D8:EB:DC:A4:2C:DA:88:55:C5:19:71:D3:9B:43:BA:AC:3A:CE:33:8E:07:52:1C:51:01:A0:97:43:C9:4D',  # noqa
+            'san': [],
+            'domains': [],
+        }
+        for key, value in list(expected.items()):
+            self.assertEqual(response.data[key], value, key)
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        Certificate.objects.create(
+            name='random-test-cert',
+            owner=self.user,
+            common_name='autotest.example.com',
+            certificate=self.cert
+        )
+        url = '/v2/certs/random-test-cert'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+
+    def test_create_invalid_cert(self):
+        """Upload a cert that can't be loaded by pyopenssl"""
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'random-test-cert',
+                'certificate': 'i am bad data',
+                'key': 'i am bad data as well'
+            }
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        # match partial since right now the rest is pyopenssl errors
+        self.assertIn('Could not load certificate', response.data['certificate'][0])
+
+    def test_load_invalid_cert(self):
+        """Inject a cert that can't be loaded by pyopenssl"""
+
+        with self.assertRaises(SuspiciousOperation):
+            Certificate.objects.create(
+                owner=self.user,
+                name='random-test-cert',
+                certificate='i am bad data',
+                key='i am bad data as well'
+            )

--- a/rootfs/api/tests/deployments/test_certificate_use_case_1.py
+++ b/rootfs/api/tests/deployments/test_certificate_use_case_1.py
@@ -1,0 +1,188 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Certificate, Domain
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateUseCase1Test(APITestCase):
+
+    """
+    Tests creation of domain SSL certificate and attach the
+    certificate to a domain and then detach
+    """
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app-use-case-1')
+        self.domain = Domain.objects.create(owner=self.user, app=self.app, domain='foo.com')
+        self.name = 'foo-com'  # certificate name
+
+        with open('{}/certs/{}.key'.format(TEST_ROOT, self.domain)) as f:
+            self.key = f.read()
+
+        with open('{}/certs/{}.cert'.format(TEST_ROOT, self.domain)) as f:
+            self.cert = f.read()
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        response = self.client.post(
+            self.url,
+            {
+                'name': self.name,
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_create_certificate_with_different_common_name(self):
+        """
+        Make sure common_name is read-only
+        """
+        response = self.client.post(
+            self.url,
+            {
+                'name': self.name,
+                'certificate': self.cert,
+                'key': self.key,
+                'common_name': 'foo.example.com'
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['common_name'], 'foo.com')
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate make sure proper data is returned
+        """
+        # Create certificate
+        response = self.client.post(
+            self.url,
+            {
+                'name': self.name,
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Attach to domain that does not exist
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, self.name),
+            {'domain': 'random.com'}
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Attach domain to certificate
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, self.name),
+            {'domain': str(self.domain)}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Assert data
+        response = self.client.get('{}/{}'.format(self.url, self.name))
+        self.assertEqual(response.status_code, 200, response.data)
+
+        expected = {
+            'name': self.name,
+            'common_name': str(self.domain),
+            'expires': '2017-01-14T23:55:59Z',
+            'fingerprint': 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6',  # noqa
+            'san': [],
+            'domains': ['foo.com']
+        }
+        for key, value in list(expected.items()):
+            self.assertEqual(response.data[key], value, key)
+
+        # detach domain from a certificate
+        response = self.client.delete(
+            '{}/{}/domain/{}'.format(self.url, self.name, self.domain)
+        )
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # detach a domain that does not exist from a certificate
+        response = self.client.delete(
+            '{}/{}/domain/{}'.format(self.url, self.name, 'i-am-fake.com')
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Assert data
+        response = self.client.get('{}/{}'.format(self.url, self.name))
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['domains'], [])
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        Certificate.objects.create(
+            owner=self.user,
+            name=self.name,
+            certificate=self.cert
+        )
+
+        url = '/v2/certs/{}'.format(self.name)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+
+    def test_delete_certificate_with_attached_domain(self):
+        """
+        Destroy a certificate with attached domain.
+        Domain should not have assigned cert anymore
+        """
+        # Create certificate
+        response = self.client.post(
+            self.url,
+            {
+                'name': self.name,
+                'certificate': self.cert,
+                'key': self.key
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Attach domain to certificate
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, self.name),
+            {'domain': str(self.domain)}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Assert data from cert side
+        response = self.client.get('{}/{}'.format(self.url, self.name))
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['domains'], [str(self.domain)])
+
+        # Assert data from domain side
+        domain = Domain.objects.get(id=self.domain.id)
+        self.assertEqual(domain.certificate.name, self.name)
+
+        # Delete certificate
+        url = '/v2/certs/{}'.format(self.name)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # verify certificate is not attached to domain anymore
+        domain = Domain.objects.get(id=self.domain.id)
+        self.assertEqual(domain.certificate, None)

--- a/rootfs/api/tests/deployments/test_certificate_use_case_2.py
+++ b/rootfs/api/tests/deployments/test_certificate_use_case_2.py
@@ -1,0 +1,138 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Certificate, Domain
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateUseCase2Test(APITestCase):
+
+    """
+    Tests creation of 2 domains and SSL certificate.
+    Attach the certificate to only one domain and then detach.
+    """
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app-use-case-2')
+        self.domains = {
+            'foo.com': Domain.objects.create(owner=self.user, app=self.app, domain='foo.com'),
+            'bar.com': Domain.objects.create(owner=self.user, app=self.app, domain='bar.com'),
+        }
+
+        # only foo.com has a cert
+        self.domain = 'foo.com'
+
+        self.certificates = {self.domain: {'name': self.domain.replace('.', '-')}}
+        with open('{}/certs/{}.key'.format(TEST_ROOT, self.domain)) as f:
+            self.certificates[self.domain]['key'] = f.read()
+
+        with open('{}/certs/{}.cert'.format(TEST_ROOT, self.domain)) as f:
+            self.certificates[self.domain]['cert'] = f.read()
+
+        # add expires and fingerprints
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
+        self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        for domain, certificate in self.certificates.items():
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate, only the common name and expiry date should be
+        displayed.
+        """
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Attach domain to certificate
+            response = self.client.post(
+                '{}/{}/domain/'.format(self.url, certificate['name']),
+                {'domain': domain}
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Assert data
+            response = self.client.get(
+                '{}/{}'.format(self.url, certificate['name'])
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+
+            expected = {
+                'name': certificate['name'],
+                'common_name': str(domain),
+                'expires': certificate['expires'],
+                'fingerprint': certificate['fingerprint'],
+                'san': [],
+                'domains': [domain]
+            }
+            for key, value in list(expected.items()):
+                self.assertEqual(
+                    response.data[key],
+                    value,
+                    '{} - {}'.format(certificate['name'], key)
+                )
+
+            # detach domain to certificate
+            response = self.client.delete(
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
+            )
+            self.assertEqual(response.status_code, 204, response.data)
+
+            # Assert data
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
+            self.assertEqual(response.status_code, 200, response.data)
+            self.assertEqual(response.data['domains'], [])
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        for domain, certificate in self.certificates.items():
+            Certificate.objects.create(
+                name=certificate['name'],
+                owner=self.user,
+                common_name=domain,
+                certificate=certificate['cert']
+            )
+            url = '/v2/certs/{}'.format(certificate['name'])
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/deployments/test_certificate_use_case_3.py
+++ b/rootfs/api/tests/deployments/test_certificate_use_case_3.py
@@ -1,0 +1,140 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Certificate, Domain
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateUseCase3Test(APITestCase):
+
+    """
+    Tests creation of 2 domains and 2 SSL certificate.
+    Attach each certificate to a matching domain and then detach.
+    """
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app-use-case-3')
+        self.domains = {
+            'foo.com': Domain.objects.create(owner=self.user, app=self.app, domain='foo.com'),
+            'bar.com': Domain.objects.create(owner=self.user, app=self.app, domain='bar.com'),
+        }
+
+        self.certificates = {}
+
+        # load up the certs
+        for domain in self.domains:
+            self.certificates[domain] = {'name': domain.replace('.', '-')}
+            with open('{}/certs/{}.key'.format(TEST_ROOT, domain)) as f:
+                self.certificates[domain]['key'] = f.read()
+
+            with open('{}/certs/{}.cert'.format(TEST_ROOT, domain)) as f:
+                self.certificates[domain]['cert'] = f.read()
+
+        # add expires and fingerprints
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
+        self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
+
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
+        self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        for domain, certificate in self.certificates.items():
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate, only the common name and expiry date should be
+        displayed.
+        """
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Attach domain to certificate
+            response = self.client.post(
+                '{}/{}/domain/'.format(self.url, certificate['name']),
+                {'domain': domain}
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Assert data
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
+            self.assertEqual(response.status_code, 200, response.data)
+
+            expected = {
+                'name': certificate['name'],
+                'common_name': str(domain),
+                'expires': certificate['expires'],
+                'fingerprint': certificate['fingerprint'],
+                'san': [],
+                'domains': [domain]
+            }
+            for key, value in list(expected.items()):
+                self.assertEqual(
+                    response.data[key],
+                    value,
+                    '{} - {}'.format(certificate['name'], key)
+                )
+
+            # detach certificate from domain
+            response = self.client.delete(
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
+            )
+            self.assertEqual(response.status_code, 204, response.data)
+
+            # Assert data
+            response = self.client.get('{}/{}'.format(self.url, certificate['name']))
+            self.assertEqual(response.status_code, 200, response.data)
+            self.assertEqual(response.data['domains'], [])
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        for domain, certificate in self.certificates.items():
+            Certificate.objects.create(
+                name=certificate['name'],
+                owner=self.user,
+                common_name=domain,
+                certificate=certificate['cert']
+            )
+            url = '/v2/certs/{}'.format(certificate['name'])
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/deployments/test_certificate_use_case_4.py
+++ b/rootfs/api/tests/deployments/test_certificate_use_case_4.py
@@ -1,0 +1,222 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Certificate, Domain
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateUseCase4Test(APITestCase):
+
+    """
+    Tests creation of 3 domains (one is a wildcard) and 3 SSL certificate (no wildcards).
+    Attach each certificate to a matching domain and then detach.
+    """
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app-use-case-3')
+        self.domains = {
+            '*.foo.com': Domain.objects.create(owner=self.user, app=self.app, domain='*.foo.com'),
+            'foo.com': Domain.objects.create(owner=self.user, app=self.app, domain='foo.com'),
+            'bar.com': Domain.objects.create(owner=self.user, app=self.app, domain='bar.com'),
+        }
+
+        self.certificates = {}
+
+        # load up the certs
+        for domain in self.domains:
+            self.certificates[domain] = {'name': domain.replace('.', '-').replace('*', 'wildcard')}
+            filename = domain
+            if '*' in domain:
+                # Cheap hack
+                filename = domain.replace('*', 'www')
+
+            with open('{}/certs/{}.key'.format(TEST_ROOT, filename)) as f:
+                self.certificates[domain]['key'] = f.read()
+
+            with open('{}/certs/{}.cert'.format(TEST_ROOT, filename)) as f:
+                self.certificates[domain]['cert'] = f.read()
+
+        # add expires, common_name and fingerprints
+        self.certificates['*.foo.com']['expires'] = '2017-01-14T23:59:02Z'
+        self.certificates['*.foo.com']['fingerprint'] = '35:FA:8F:58:FF:EA:E0:22:79:29:0B:85:58:73:C2:A5:CD:4A:D9:81:D7:10:9D:4D:03:43:41:E4:1D:92:AB:C5'  # noqa
+        self.certificates['*.foo.com']['common_name'] = 'www.foo.com'
+
+        self.certificates['foo.com']['expires'] = '2017-01-14T23:55:59Z'
+        self.certificates['foo.com']['fingerprint'] = 'AC:82:58:80:EA:C4:B9:75:C1:1C:52:48:40:28:15:1D:47:AC:ED:88:4B:D4:72:95:B2:C0:A0:DF:4A:A7:60:B6'  # noqa
+        self.certificates['foo.com']['common_name'] = 'foo.com'
+
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
+        self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
+        self.certificates['bar.com']['common_name'] = 'bar.com'
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        for domain, certificate in self.certificates.items():
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate, only the common name and expiry date should be
+        displayed.
+        """
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Attach domain to certificate
+            response = self.client.post(
+                '{}/{}/domain/'.format(self.url, certificate['name']),
+                {'domain': domain}
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Assert data
+            response = self.client.get(
+                '{}/{}'.format(self.url, certificate['name'])
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+
+            expected = {
+                'name': certificate['name'],
+                'common_name': certificate['common_name'],
+                'expires': certificate['expires'],
+                'fingerprint': certificate['fingerprint'],
+                'san': [],
+                'domains': [domain]
+            }
+            for key, value in list(expected.items()):
+                self.assertEqual(
+                    response.data[key],
+                    value,
+                    '{} - {}'.format(certificate['name'], key)
+                )
+
+            # detach domain to certificate
+            response = self.client.delete(
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
+            )
+            self.assertEqual(response.status_code, 204, response.data)
+
+            # Assert data
+            response = self.client.get(
+                '{}/{}'.format(self.url, certificate['name'])
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+            self.assertEqual(response.data['domains'], [])
+
+    def test_certificate_attach_overwrite(self):
+        """
+        Test if a certificate can be overwritten with another on a domain
+        """
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+        # Attach domain to certificate
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, 'foo-com'),
+            {'domain': 'foo.com'}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Attach domain to a second certificate
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, 'bar-com'),
+            {'domain': 'foo.com'}
+        )
+        # Should be a 409 Conflict since it already existed
+        self.assertEqual(response.status_code, 409)
+
+        # Assert that domain and cert are still the original
+        response = self.client.get(
+            '{}/{}'.format(self.url, 'foo-com')
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+
+        expected = {
+            'name': 'foo-com',
+            'common_name': 'foo.com',
+            'domains': ['foo.com']
+        }
+        for key, value in list(expected.items()):
+            self.assertEqual(
+                response.data[key],
+                value,
+                '{} - {}'.format('foo-com', key)
+            )
+
+        response = self.client.get(
+            '{}/{}'.format(self.url, 'bar-com')
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+
+        expected = {
+            'name': 'bar-com',
+            'common_name': 'bar.com',
+            'domains': []
+        }
+        for key, value in list(expected.items()):
+            self.assertEqual(
+                response.data[key],
+                value,
+                '{} - {}'.format('bar-com', key)
+            )
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        for domain, certificate in self.certificates.items():
+            Certificate.objects.create(
+                name=certificate['name'],
+                owner=self.user,
+                common_name=domain,
+                certificate=certificate['cert']
+            )
+            url = '/v2/certs/{}'.format(certificate['name'])
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/deployments/test_certificate_use_case_5.py
+++ b/rootfs/api/tests/deployments/test_certificate_use_case_5.py
@@ -1,0 +1,170 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Certificate, Domain
+from api.tests import TEST_ROOT
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class CertificateUseCase5Test(APITestCase):
+
+    """
+    Tests creation of 3 domains (one is a wildcard) and 2 SSL certificate (one is a wildcard).
+    Attach each certificate to a matching domain(s) and then detach.
+    """
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        self.url = '/v2/certs'
+        self.app = App.objects.create(owner=self.user, id='test-app-use-case-5')
+        # Done out of scope as it gets the same cert as the wildcard
+        Domain.objects.create(owner=self.user, app=self.app, domain='foo.com')
+        self.domains = {
+            '*.foo.com': Domain.objects.create(owner=self.user, app=self.app, domain='*.foo.com'),
+            'bar.com': Domain.objects.create(owner=self.user, app=self.app, domain='bar.com'),
+        }
+
+        self.certificates = {}
+
+        # load up the certs
+        for domain in self.domains:
+            self.certificates[domain] = {'name': domain.replace('.', '-').replace('*', 'wildcard')}
+            filename = domain.replace('*', 'wildcard')
+
+            with open('{}/certs/{}.key'.format(TEST_ROOT, filename)) as f:
+                self.certificates[domain]['key'] = f.read()
+
+            with open('{}/certs/{}.cert'.format(TEST_ROOT, filename)) as f:
+                self.certificates[domain]['cert'] = f.read()
+
+        # add expires, common_name and fingerprints
+        self.certificates['*.foo.com']['expires'] = '2017-01-21T21:56:15Z'
+        self.certificates['*.foo.com']['fingerprint'] = '8F:8E:5F:F6:7A:78:07:5B:75:3E:10:D5:91:AE:30:4A:48:F4:40:39:90:12:88:B3:41:C6:68:7F:62:F5:CD:EB'  # noqa
+        self.certificates['*.foo.com']['common_name'] = '*.foo.com'
+        self.certificates['*.foo.com']['san'] = ['foo.com']
+
+        self.certificates['bar.com']['expires'] = '2017-01-14T23:57:57Z'
+        self.certificates['bar.com']['fingerprint'] = '7A:CA:B8:50:FF:8D:EB:03:3D:AC:AD:13:4F:EE:03:D5:5D:EB:5E:37:51:8C:E0:98:F8:1B:36:2B:20:83:0D:C0'  # noqa
+        self.certificates['bar.com']['common_name'] = 'bar.com'
+        self.certificates['bar.com']['san'] = []
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_create_certificate_with_domain(self):
+        """Tests creating a certificate."""
+        for domain, certificate in self.certificates.items():
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+    def test_get_certificate_screens_data(self):
+        """
+        When a user retrieves a certificate, only the common name and expiry date should be
+        displayed.
+        """
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            response = self.client.post(
+                self.url,
+                {
+                    'name': certificate['name'],
+                    'certificate': certificate['cert'],
+                    'key': certificate['key']
+                }
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            # Attach domain to certificate
+            response = self.client.post(
+                '{}/{}/domain/'.format(self.url, certificate['name']),
+                {'domain': domain}
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+            if certificate['san']:
+                for san in certificate['san']:
+                    response = self.client.post(
+                        '{}/{}/domain/'.format(self.url, certificate['name']),
+                        {'domain': san}
+                    )
+                    self.assertEqual(response.status_code, 201, response.data)
+
+            # Assert data
+            response = self.client.get(
+                '{}/{}'.format(self.url, certificate['name'])
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+
+            expected = {
+                'name': certificate['name'],
+                'common_name': certificate['common_name'],
+                'expires': certificate['expires'],
+                'fingerprint': certificate['fingerprint'],
+                'san': certificate['san'],
+                'domains': [domain] + certificate['san']
+            }
+            for key, value in list(expected.items()):
+                self.assertEqual(
+                    response.data[key],
+                    value,
+                    '{} - {}'.format(certificate['name'], key)
+                )
+
+            # detach domain from certificate
+            response = self.client.delete(
+                '{}/{}/domain/{}'.format(self.url, certificate['name'], domain)
+            )
+            self.assertEqual(response.status_code, 204, response.data)
+
+            if certificate['san']:
+                for san in certificate['san']:
+                    response = self.client.delete(
+                        '{}/{}/domain/{}'.format(self.url, certificate['name'], san)
+                    )
+                    self.assertEqual(response.status_code, 204, response.data)
+
+            # Assert data
+            response = self.client.get(
+                '{}/{}'.format(self.url, certificate['name'])
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+            self.assertEqual(response.data['domains'], [])
+
+    def test_certficate_denied_requests(self):
+        """Disallow put/patch requests"""
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_delete_certificate(self):
+        """Destroying a certificate should generate a 204 response"""
+        for domain, certificate in self.certificates.items():
+            # Create certificate
+            Certificate.objects.create(
+                name=certificate['name'],
+                owner=self.user,
+                common_name=domain,
+                certificate=certificate['cert']
+            )
+
+            # Remove certificate
+            url = '/v2/certs/{}'.format(certificate['name'])
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, response.data)

--- a/rootfs/api/tests/deployments/test_config.py
+++ b/rootfs/api/tests/deployments/test_config.py
@@ -1,0 +1,975 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+import json
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+from unittest import mock
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Config
+
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class ConfigTest(APITransactionTestCase):
+
+    """Tests setting and updating config values"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        url = '/v2/apps'
+        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 201, response.data)
+        self.app = App.objects.all()[0]
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_config(self, mock_requests):
+        """
+        Test that config is auto-created for a new app and that
+        config can be updated using a PATCH
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check to see that an initial/empty config was created
+        url = "/v2/apps/{app_id}/config".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('values', response.data)
+        self.assertEqual(response.data['values'], {})
+        config1 = response.data
+
+        # set an initial config value
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        config2 = response.data
+        self.assertNotEqual(config1['uuid'], config2['uuid'])
+        self.assertIn('NEW_URL1', response.data['values'])
+
+        # read the config
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        config3 = response.data
+        self.assertEqual(config2, config3)
+        self.assertIn('NEW_URL1', response.data['values'])
+
+        # set an additional config value
+        body = {'values': json.dumps({'NEW_URL2': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        config3 = response.data
+        self.assertNotEqual(config2['uuid'], config3['uuid'])
+        self.assertIn('NEW_URL1', response.data['values'])
+        self.assertIn('NEW_URL2', response.data['values'])
+
+        # read the config again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        config4 = response.data
+        self.assertEqual(config3, config4)
+        self.assertIn('NEW_URL1', response.data['values'])
+        self.assertIn('NEW_URL2', response.data['values'])
+
+        # unset a config value
+        body = {'values': json.dumps({'NEW_URL2': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        config5 = response.data
+        self.assertNotEqual(config4['uuid'], config5['uuid'])
+        self.assertNotIn('NEW_URL2', json.dumps(response.data['values']))
+
+        # unset all config values
+        body = {'values': json.dumps({'NEW_URL1': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertNotIn('NEW_URL1', json.dumps(response.data['values']))
+
+        # set a port and then unset it to make sure validation ignores the unset
+        body = {'values': json.dumps({'PORT': '5000'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('PORT', response.data['values'])
+
+        body = {'values': json.dumps({'PORT': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertNotIn('PORT', response.data['values'])
+
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        return config5
+
+    def test_response_data(self, mock_requests):
+        """Test that the serialized response contains only relevant data."""
+        body = {'id': 'test'}
+        response = self.client.post('/v2/apps', body)
+        url = "/v2/apps/test/config"
+
+        # set an initial config value
+        body = {'values': json.dumps({'PORT': '5000'})}
+        response = self.client.post(url, body)
+        for key in response.data:
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'values', 'memory',
+                                'cpu', 'tags', 'registry', 'healthcheck'])
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'values': {'PORT': '5000'},
+            'memory': {},
+            'cpu': {},
+            'tags': {},
+            'registry': {}
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+    def test_response_data_types_converted(self, mock_requests):
+        """Test that config data is converted into the correct type."""
+        body = {'id': 'test'}
+        response = self.client.post('/v2/apps', body)
+        url = "/v2/apps/test/config"
+
+        body = {'values': json.dumps({'PORT': 5000}), 'cpu': json.dumps({'web': '1024'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        for key in response.data:
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'values', 'memory',
+                                'cpu', 'tags', 'registry', 'healthcheck'])
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'values': {'PORT': '5000'},
+            'memory': {},
+            'cpu': {'web': "1024"},
+            'tags': {},
+            'registry': {}
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+        body = {'cpu': json.dumps({'web': 'this will fail'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('CPU shares must be a numeric value', response.data['cpu'])
+
+    def test_config_set_same_key(self, mock_requests):
+        """
+        Test that config sets on the same key function properly
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = "/v2/apps/{app_id}/config".format(**locals())
+
+        # set an initial config value
+        body = {'values': json.dumps({'PORT': '5000'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('PORT', response.data['values'])
+
+        # reset same config value
+        body = {'values': json.dumps({'PORT': '5001'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('PORT', response.data['values'])
+        self.assertEqual(response.data['values']['PORT'], '5001')
+
+    def test_config_set_unicode(self, mock_requests):
+        """
+        Test that config sets with unicode values are accepted.
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = "/v2/apps/{app_id}/config".format(**locals())
+
+        # set an initial config value
+        body = {'values': json.dumps({'POWERED_BY': 'Деис'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('POWERED_BY', response.data['values'])
+        # reset same config value
+        body = {'values': json.dumps({'POWERED_BY': 'Кроликов'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('POWERED_BY', response.data['values'])
+        self.assertEqual(response.data['values']['POWERED_BY'], 'Кроликов')
+
+        # set an integer to test unicode regression
+        body = {'values': json.dumps({'INTEGER': 1})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('INTEGER', response.data['values'])
+        self.assertEqual(response.data['values']['INTEGER'], '1')
+
+    def test_config_str(self, mock_requests):
+        """Test the text representation of a node."""
+        config5 = self.test_config()
+        config = Config.objects.get(uuid=config5['uuid'])
+        self.assertEqual(str(config), "{}-{}".format(config5['app'], str(config5['uuid'])[:7]))
+
+    def test_valid_config_keys(self, mock_requests):
+        """Test that valid config keys are accepted.
+        """
+        keys = ("FOO", "_foo", "f001", "FOO_BAR_BAZ_")
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        for k in keys:
+            body = {'values': json.dumps({k: "testvalue"})}
+            resp = self.client.post(url, body)
+            self.assertEqual(resp.status_code, 201)
+            self.assertIn(k, resp.data['values'])
+
+    def test_config_deploy_failure(self, mock_requests):
+        """
+        Cause an Exception in app.deploy to cause a release.delete
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # deploy app to get a build
+        url = "/v2/apps/{}/builds".format(app_id)
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        with mock.patch('api.models.App.deploy') as mock_deploy:
+            mock_deploy.side_effect = Exception('Boom!')
+            url = '/v2/apps/{app_id}/config'.format(**locals())
+            body = {'values': json.dumps({'test': "testvalue"})}
+            resp = self.client.post(url, body)
+            self.assertEqual(resp.status_code, 400)
+
+    def test_invalid_config_keys(self, mock_requests):
+        """Test that invalid config keys are rejected.
+        """
+        keys = ("123", "../../foo", "FOO/", "FOO-BAR")
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        for k in keys:
+            body = {'values': json.dumps({k: "testvalue"})}
+            resp = self.client.post(url, body)
+            self.assertEqual(resp.status_code, 400)
+
+    def test_invalid_config_values(self, mock_requests):
+        """
+        Test that invalid config values are rejected.
+        Right now only PORT is checked
+        """
+        data = [
+            {'field': 'PORT', 'value': 'dog'},
+            {'field': 'PORT', 'value': 99999}
+        ]
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        for row in data:
+            body = {'values': json.dumps({row['field']: row['value']})}
+            resp = self.client.post(url, body)
+            self.assertEqual(resp.status_code, 400, response.data)
+
+    def test_admin_can_create_config_on_other_apps(self, mock_requests):
+        """If a non-admin creates an app, an administrator should be able to set config
+        values for that app.
+        """
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        url = '/v2/apps'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = "/v2/apps/{app_id}/config".format(**locals())
+
+        # set an initial config value
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        body = {'values': json.dumps({'PORT': '5000'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('PORT', response.data['values'])
+        return response
+
+    def test_limit_memory(self, mock_requests):
+        """
+        Test that limit is auto-created for a new app and that
+        limits can be updated using a PATCH
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+
+        # check default limit
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('memory', response.data)
+        self.assertEqual(response.data['memory'], {})
+        # regression test for https://github.com/deis/deis/issues/1563
+        self.assertNotIn('"', response.data['memory'])
+
+        # set an initial limit
+        mem = {'web': '1G'}
+        body = {'memory': json.dumps(mem)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit1 = response.data
+
+        # check memory limits
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('memory', response.data)
+        memory = response.data['memory']
+        self.assertIn('web', memory)
+        self.assertEqual(memory['web'], '1G')
+
+        # set an additional value
+        body = {'memory': json.dumps({'worker': '512M'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit2 = response.data
+        self.assertNotEqual(limit1['uuid'], limit2['uuid'])
+        memory = response.data['memory']
+        self.assertIn('worker', memory)
+        self.assertEqual(memory['worker'], '512M')
+        self.assertIn('web', memory)
+        self.assertEqual(memory['web'], '1G')
+
+        # read the limit again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        limit3 = response.data
+        self.assertEqual(limit2, limit3)
+        memory = response.data['memory']
+        self.assertIn('worker', memory)
+        self.assertEqual(memory['worker'], '512M')
+        self.assertIn('web', memory)
+        self.assertEqual(memory['web'], '1G')
+
+        # regression test for https://github.com/deis/deis/issues/1613
+        # ensure that config:set doesn't wipe out previous limits
+        body = {'values': json.dumps({'NEW_URL2': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('NEW_URL2', response.data['values'])
+
+        # read the limit again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        memory = response.data['memory']
+        self.assertIn('worker', memory)
+        self.assertEqual(memory['worker'], '512M')
+        self.assertIn('web', memory)
+        self.assertEqual(memory['web'], '1G')
+
+        # unset a value
+        body = {'memory': json.dumps({'worker': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit4 = response.data
+        self.assertNotEqual(limit3['uuid'], limit4['uuid'])
+        self.assertNotIn('worker', json.dumps(response.data['memory']))
+
+        # bad memory values
+        mem = {'web': '1Z'}
+        body = {'memory': json.dumps(mem)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        mem = {'w3&b': '1G'}
+        body = {'memory': json.dumps(mem)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        return limit4
+
+    def test_limit_cpu(self, mock_requests):
+        """
+        Test that CPU limits can be set
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+
+        # check default limit
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('cpu', response.data)
+        self.assertEqual(response.data['cpu'], {})
+        # regression test for https://github.com/deis/deis/issues/1563
+        self.assertNotIn('"', response.data['cpu'])
+
+        # set an initial limit
+        body = {'cpu': json.dumps({'web': '1024'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit1 = response.data
+
+        # check memory limits
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('cpu', response.data)
+        cpu = response.data['cpu']
+        self.assertIn('web', cpu)
+        self.assertEqual(cpu['web'], '1024')
+
+        # set an additional value
+        body = {'cpu': json.dumps({'worker': '512m'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit2 = response.data
+        self.assertNotEqual(limit1['uuid'], limit2['uuid'])
+        cpu = response.data['cpu']
+        self.assertIn('worker', cpu)
+        self.assertEqual(cpu['worker'], '512m')
+        self.assertIn('web', cpu)
+        self.assertEqual(cpu['web'], '1024')
+
+        # read the limit again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        limit3 = response.data
+        self.assertEqual(limit2, limit3)
+        cpu = response.data['cpu']
+        self.assertIn('worker', cpu)
+        self.assertEqual(cpu['worker'], '512m')
+        self.assertIn('web', cpu)
+        self.assertEqual(cpu['web'], '1024')
+
+        # unset a value
+        body = {'cpu': json.dumps({'worker': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        limit4 = response.data
+        self.assertNotEqual(limit3['uuid'], limit4['uuid'])
+        self.assertNotIn('worker', json.dumps(response.data['cpu']))
+
+        # bad cpu values
+        mem = {'web': '1G'}
+        body = {'cpu': json.dumps(mem)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        mem = {'w3&b': '1G'}
+        body = {'cpu': json.dumps(mem)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        return limit4
+
+    def test_tags(self, mock_requests):
+        """
+        Test that tags can be set on an application
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check default
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('tags', response.data)
+        self.assertEqual(response.data['tags'], {})
+
+        # set some tags
+        body = {'tags': json.dumps({'environ': 'dev'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        tags1 = response.data
+
+        # check tags again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('tags', response.data)
+        tags = response.data['tags']
+        self.assertIn('environ', tags)
+        self.assertEqual(tags['environ'], 'dev')
+
+        # set an additional value
+        body = {'tags': json.dumps({'rack': '1'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        tags2 = response.data
+        self.assertNotEqual(tags1['uuid'], tags2['uuid'])
+        tags = response.data['tags']
+        self.assertIn('rack', tags)
+        self.assertEqual(tags['rack'], '1')
+        self.assertIn('environ', tags)
+        self.assertEqual(tags['environ'], 'dev')
+
+        # read the limit again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        tags3 = response.data
+        self.assertEqual(tags2, tags3)
+        tags = response.data['tags']
+        self.assertIn('rack', tags)
+        self.assertEqual(tags['rack'], '1')
+        self.assertIn('environ', tags)
+        self.assertEqual(tags['environ'], 'dev')
+
+        # unset a value
+        body = {'tags': json.dumps({'rack': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        tags4 = response.data
+        self.assertNotEqual(tags3['uuid'], tags4['uuid'])
+        self.assertNotIn('rack', json.dumps(response.data['tags']))
+
+        # set valid values
+        body = {'tags': json.dumps({'kubernetes.io/hostname': '172.17.8.100'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        body = {'tags': json.dumps({'is.valid': 'is-also_valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        body = {'tags': json.dumps({'host.the-name.com/is.valid': 'valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        body = {'tags': json.dumps({'host.the-name.com/does.no.exist': 'valid'})}
+        response = self.client.post(url, body)
+        self.assertContains(
+            response,
+            'Addition of host.the-name.com/does.no.exist=valid is the cause',
+            status_code=400
+        )
+
+        # set invalid values
+        body = {'tags': json.dumps({'valid': 'in\nvalid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        body = {'tags': json.dumps({'host.name.com/notvalid-': 'valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        body = {'tags': json.dumps({'valid': 'invalid.'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        body = {'tags': json.dumps({'host.name.com/,not.valid': 'valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        long_tag = 'a' * 300
+        body = {'tags': json.dumps({'{}/not.valid'.format(long_tag): 'valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        body = {'tags': json.dumps({'this&foo.com/not.valid': 'valid'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.data)
+
+    def test_registry(self, mock_requests):
+        """
+        Test that registry information can be set on an application
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check default
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('registry', response.data)
+        self.assertEqual(response.data['registry'], {})
+
+        # set some registry information without PORT
+        body = {'registry': json.dumps({'username': 'bob'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        registry1 = response.data
+
+        # set required PORT
+        body = {'values': json.dumps({'PORT': '80'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        registry1 = response.data
+
+        # set some registry information
+        body = {'registry': json.dumps({'username': 'bob'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        registry1 = response.data
+
+        # check registry information again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('registry', response.data)
+        registry = response.data['registry']
+        self.assertIn('username', registry)
+        self.assertEqual(registry['username'], 'bob')
+
+        # set an additional value
+        # set them upper case, internally it should translate to lower
+        body = {'registry': json.dumps({'PASSWORD': 's3cur3pw1'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        registry2 = response.data
+        self.assertNotEqual(registry1['uuid'], registry2['uuid'])
+        registry = response.data['registry']
+        self.assertIn('password', registry)
+        self.assertEqual(registry['password'], 's3cur3pw1')
+        self.assertIn('username', registry)
+        self.assertEqual(registry['username'], 'bob')
+
+        # read the registry information again
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        registry3 = response.data
+        self.assertEqual(registry2, registry3)
+        registry = response.data['registry']
+        self.assertIn('password', registry)
+        self.assertEqual(registry['password'], 's3cur3pw1')
+        self.assertIn('username', registry)
+        self.assertEqual(registry['username'], 'bob')
+
+        # unset a value
+        body = {'registry': json.dumps({'password': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        registry4 = response.data
+        self.assertNotEqual(registry3['uuid'], registry4['uuid'])
+        self.assertNotIn('password', json.dumps(response.data['registry']))
+
+        # bad registry key values
+        body = {'registry': json.dumps({'pa$$w0rd': 'woop'})}
+        response = self.client.post(url, body)
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # disallow put/patch/delete
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.data)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.data)
+
+    def test_registry_deploy(self, mock_requests):
+        """
+        Test that registry information can be applied
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # Set mandatory PORT
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'PORT': '4999'})}
+        )
+
+        # Set registry information
+        body = {'registry': json.dumps({
+            'username': 'bob',
+            'password': 's3cur3pw1'
+        })}
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            body
+        )
+        self.assertEqual(resp.status_code, 201, response.data)
+        self.assertIn('username', resp.data['registry'])
+        self.assertIn('password', resp.data['registry'])
+        self.assertEqual(resp.data['registry']['username'], 'bob')
+        self.assertEqual(resp.data['registry']['password'], 's3cur3pw1')
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_config_owner_is_requesting_user(self, mock_requests):
+        """
+        Ensure that setting the config value is owned by the requesting user
+        See https://github.com/deis/deis/issues/2650
+        """
+        response = self.test_admin_can_create_config_on_other_apps()
+        self.assertEqual(response.data['owner'], self.user.username)
+
+    def test_unauthorized_user_cannot_modify_config(self, mock_requests):
+        """
+        An unauthorized user should not be able to modify other config.
+
+        Since an unauthorized user can't access the application, these
+        requests should return a 403.
+        """
+        app_id = 'autotest'
+        base_url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(base_url, body)
+
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+        url = '{}/{}/config'.format(base_url, app_id)
+        body = {'values': {'FOO': 'bar'}}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+
+    def test_healthchecks(self, mock_requests):
+        """
+        Test that healthchecks can be applied
+        """
+        response = self.client.post('/v2/apps')
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # Set a healthcheck option before URL is around (URL is required for full setting)
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_INITIAL_DELAY': '25'})}
+        )
+        self.assertEqual(resp.status_code, 201, response.data)
+        self.assertIn('HEALTHCHECK_INITIAL_DELAY', resp.data['values'])
+        self.assertEqual(resp.data['values']['HEALTHCHECK_INITIAL_DELAY'], '25')
+
+        # Set healthcheck URL to get defaults set
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': '/health'})}
+        )
+        self.assertEqual(resp.status_code, 201, response.data)
+        self.assertIn('HEALTHCHECK_URL', resp.data['values'])
+        self.assertEqual(resp.data['values']['HEALTHCHECK_URL'], '/health')
+
+        # post a new build
+        response = self.client.post(
+            "/v2/apps/{app_id}/builds".format(**locals()),
+            {'image': 'quay.io/autotest/example'}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_healthchecks_validations(self, mock_requests):
+        """
+        Test that healthchecks validations work
+        """
+        response = self.client.post('/v2/apps')
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # Set one of the values that require a numeric value to a string
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_INITIAL_DELAY': 'horse'})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # test URL - Path is the only allowed thing
+        # Try setting various things such as query param
+
+        # query param
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': '/health?testing=0'})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # fragment
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': '/health#db'})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # netloc
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': 'http://someurl.com/health/'})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # no path
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': 'http://someurl.com'})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+    def test_config_healthchecks(self, mock_requests):
+        """
+        Test that healthchecks can be applied
+        """
+        response = self.client.post('/v2/apps')
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        readiness_probe = {'healthcheck': {'readinessProbe': {'httpGet': {'port': 5000}}}}
+
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            readiness_probe)
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertIn('readinessProbe', resp.data['healthcheck'])
+        self.assertEqual(resp.data['healthcheck'], readiness_probe['healthcheck'])
+
+        liveness_probe = {'healthcheck': {'livenessProbe': {'httpGet': {'port': 5000}}}}
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            liveness_probe)
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertIn('livenessProbe', resp.data['healthcheck'])
+        self.assertEqual(
+            resp.data['healthcheck']['livenessProbe'],
+            liveness_probe['healthcheck']['livenessProbe'])
+        # check that the readiness probe is still there too!
+        self.assertIn('readinessProbe', resp.data['healthcheck'])
+        self.assertEqual(
+            resp.data['healthcheck']['readinessProbe'],
+            readiness_probe['healthcheck']['readinessProbe'])
+
+        # post a new build
+        response = self.client.post(
+            "/v2/apps/{app_id}/builds".format(**locals()),
+            {'image': 'quay.io/autotest/example'}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_config_healthchecks_validations(self, mock_requests):
+        """
+        Test that healthchecks validations work
+        """
+        response = self.client.post('/v2/apps')
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # Set one of the values that require a numeric value to a string
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'healthcheck': json.dumps({'livenessProbe':
+                                        {'httpGet': {'port': '50'}, 'initialDelaySeconds': "t"}})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # Don't set one of the mandatory value
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'healthcheck': json.dumps({'livenessProbe':
+                                        {'httpGet': {'path': '/'}, 'initialDelaySeconds': 1}})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+    def test_config_healthchecks_legacy(self, mock_requests):
+        """
+        Test that when a user uses `deis config:set HEALTHCHECK_URL=/`, the config
+        object is rolled over to the `healthcheck` field.
+        """
+        response = self.client.post('/v2/apps')
+        self.assertEqual(response.status_code, 201, response.data)
+        app = App.objects.get(id=response.data['id'])
+
+        # Set healthcheck URL to get defaults set
+        response = self.client.post(
+            '/v2/apps/{app.id}/config'.format(**locals()),
+            {'values': json.dumps({'HEALTHCHECK_URL': '/health'})}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('HEALTHCHECK_URL', response.data['values'])
+        self.assertEqual(response.data['values']['HEALTHCHECK_URL'], '/health')
+        # legacy defaults
+        expected = {
+            'livenessProbe': {
+                'initialDelaySeconds': 50,
+                'timeoutSeconds': 50,
+                'periodSeconds': 10,
+                'successThreshold': 1,
+                'failureThreshold': 3,
+                'httpGet': {
+                    'path': '/health'
+                }
+            }
+        }
+        actual = app.config_set.latest().healthcheck
+        self.assertEqual(actual, expected)
+        # Now set all the envvars and check to make sure they are written properly
+        response = self.client.post(
+            '/v2/apps/{app.id}/config'.format(**locals()),
+            {
+                'values': json.dumps({
+                    'HEALTHCHECK_INITIAL_DELAY': '25',
+                    'HEALTHCHECK_TIMEOUT': '10',
+                    'HEALTHCHECK_PERIOD_SECONDS': '5',
+                    'HEALTHCHECK_SUCCESS_THRESHOLD': '2',
+                    'HEALTHCHECK_FAILURE_THRESHOLD': '2'})
+            }
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('HEALTHCHECK_INITIAL_DELAY', response.data['values'])
+        self.assertEqual(response.data['values']['HEALTHCHECK_INITIAL_DELAY'], '25')
+        expected['livenessProbe'] = {
+            'initialDelaySeconds': 25,
+            'timeoutSeconds': 10,
+            'periodSeconds': 5,
+            'successThreshold': 2,
+            'failureThreshold': 2,
+            'httpGet': {
+                'path': '/health'
+            }
+        }
+        actual = app.config_set.latest().healthcheck
+        self.assertEqual(expected, actual)

--- a/rootfs/api/tests/deployments/test_domain.py
+++ b/rootfs/api/tests/deployments/test_domain.py
@@ -1,0 +1,358 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+from unittest import mock
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+
+from api.models import Domain
+from scheduler import KubeException
+
+import idna
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+class DomainTest(APITestCase):
+
+    """Tests creation of domains"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.app_id = response.data['id']  # noqa
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_response_data(self):
+        """Test that the serialized response contains only relevant data."""
+        response = self.client.post(
+            '/v2/apps',
+            {'id': 'test'}
+        )
+
+        response = self.client.post(
+            '/v2/apps/test/domains',
+            {'domain': 'test-domain.example.com'}
+        )
+
+        for key in response.data:
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'domain'])
+
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'domain': 'test-domain.example.com'
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+    def test_strip_dot(self):
+        """Test that a dot on the right side of the domain gets stripped"""
+        domain = 'autotest.127.0.0.1.xip.io.'
+        msg = "failed on '{}'".format(domain)
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+
+        # Create
+        response = self.client.post(url, {'domain': domain})
+        self.assertEqual(response.status_code, 201, msg)
+
+        # Fetch
+        domain = 'autotest.127.0.0.1.xip.io'  # stripped version
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+        response = self.client.get(url)
+        expected = [data['domain'] for data in response.data['results']]
+        self.assertEqual([self.app_id, domain], expected, msg)
+
+    def test_manage_idn_domain(self):
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+        test_domains = [
+            'ドメイン.テスト',
+            'xn--eckwd4c7c.xn--zckzah',
+            'xn--80ahd1agd.ru',
+            'домена.ru',
+            '*.домена.испытание',
+            'täst.königsgäßchen.de',
+            'xn--tst-qla.xn--knigsgsschen-lcb0w.de',
+            'ドメイン.xn--zckzah',
+            'xn--eckwd4c7c.テスト',
+            'täst.xn--knigsgsschen-lcb0w.de',
+            '*.xn--tst-qla.königsgäßchen.de'
+        ]
+        for domain in test_domains:
+            msg = "failed on '{}'".format(domain)
+
+            # Generate ACE and Unicode variant for domain
+            if domain.startswith("*."):
+                ace_domain = "*." + idna.encode(domain[2:]).decode("utf-8", "strict")
+                unicode_domain = "*." + idna.decode(ace_domain[2:])
+            else:
+                ace_domain = idna.encode(domain).decode("utf-8", "strict")
+                unicode_domain = idna.decode(ace_domain)
+
+            # Create
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 201, msg)
+
+            # Fetch
+            url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+            response = self.client.get(url)
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id, ace_domain], expected, msg)
+
+            # Verify creation failure for same domain with different encoding
+            if ace_domain != domain:
+                response = self.client.post(url, {'domain': ace_domain})
+                self.assertEqual(response.status_code, 400, msg)
+
+            # Verify creation failure for same domain with different encoding
+            if unicode_domain != domain:
+                response = self.client.post(url, {'domain': unicode_domain})
+                self.assertEqual(response.status_code, 400, msg)
+
+            # Delete
+            url = '/v2/apps/{app_id}/domains/{hostname}'.format(hostname=domain,
+                                                                app_id=self.app_id)
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, msg)
+
+            # Verify removal
+            url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+            response = self.client.get(url)
+            self.assertEqual(1, response.data['count'], msg)
+
+            # verify only app domain is left
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id], expected, msg)
+
+            # Use different encoding for creating and deleting (ACE)
+            if ace_domain != domain:
+                # Create
+                response = self.client.post(url, {'domain': domain})
+                self.assertEqual(response.status_code, 201, msg)
+
+                # Fetch
+                url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+                response = self.client.get(url)
+                expected = [data['domain'] for data in response.data['results']]
+                self.assertEqual([self.app_id, ace_domain], expected, msg)
+
+                # Delete
+                url = '/v2/apps/{app_id}/domains/{hostname}'.format(hostname=ace_domain,
+                                                                    app_id=self.app_id)
+                response = self.client.delete(url)
+                self.assertEqual(response.status_code, 204, msg)
+
+                # Verify removal
+                url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+                response = self.client.get(url)
+                self.assertEqual(1, response.data['count'], msg)
+
+                # verify only app domain is left
+                expected = [data['domain'] for data in response.data['results']]
+                self.assertEqual([self.app_id], expected, msg)
+
+            # Use different encoding for creating and deleting (Unicode)
+            if unicode_domain != domain:
+                # Create
+                response = self.client.post(url, {'domain': domain})
+                self.assertEqual(response.status_code, 201, msg)
+
+                # Fetch
+                url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+                response = self.client.get(url)
+                expected = [data['domain'] for data in response.data['results']]
+                self.assertEqual([self.app_id, ace_domain], expected, msg)
+
+                # Delete
+                url = '/v2/apps/{app_id}/domains/{hostname}'.format(hostname=unicode_domain,
+                                                                    app_id=self.app_id)
+                response = self.client.delete(url)
+                self.assertEqual(response.status_code, 204, msg)
+
+                # Verify removal
+                url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+                response = self.client.get(url)
+                self.assertEqual(1, response.data['count'], msg)
+
+                # verify only app domain is left
+                expected = [data['domain'] for data in response.data['results']]
+                self.assertEqual([self.app_id], expected, msg)
+
+    def test_manage_domain(self):
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+        test_domains = [
+            'test-domain.example.com',
+            'django.paas-sandbox',
+            'django.paas--sandbox',
+            'domain',
+            'not.too.loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+            '3com.com',
+            'domain1',
+            '3333.xyz',
+            'w3.example.com',
+            'MYDOMAIN.NET',
+            'autotest.127.0.0.1.xip.io',
+            '*.deis.example.com'
+        ]
+
+        for domain in test_domains:
+            msg = "failed on '{}'".format(domain)
+
+            # Create
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 201, msg)
+
+            # Fetch
+            url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+            response = self.client.get(url)
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id, domain], expected, msg)
+
+            # Delete
+            url = '/v2/apps/{app_id}/domains/{hostname}'.format(hostname=domain,
+                                                                app_id=self.app_id)
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204, msg)
+
+            # Verify removal
+            url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+            response = self.client.get(url)
+            self.assertEqual(1, response.data['count'], msg)
+
+            # verify only app domain is left
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id], expected, msg)
+
+    def test_delete_domain_does_not_exist(self):
+        """Remove a domain that does not exist"""
+        url = '/v2/apps/{app_id}/domains/{domain}'.format(domain='test-domain.example.com',
+                                                          app_id=self.app_id)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_domain_does_not_remove_latest(self):
+        """https://github.com/deis/deis/issues/3239"""
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+        test_domains = [
+            'test-domain.example.com',
+            'django.paas-sandbox',
+        ]
+        for domain in test_domains:
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 201, response.data)
+
+        url = '/v2/apps/{app_id}/domains/{domain}'.format(domain=test_domains[0],
+                                                          app_id=self.app_id)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204, response.data)
+        with self.assertRaises(Domain.DoesNotExist):
+            Domain.objects.get(domain=test_domains[0])
+
+    def test_delete_domain_does_not_remove_others(self):
+        """https://github.com/deis/deis/issues/3475"""
+        self.test_delete_domain_does_not_remove_latest()
+        self.assertEqual(Domain.objects.all().count(), 2)
+
+    def test_manage_domain_invalid_app(self):
+        # Create domain
+        url = '/v2/apps/{app_id}/domains'.format(app_id="this-app-does-not-exist")
+        response = self.client.post(url, {'domain': 'test-domain.example.com'})
+        self.assertEqual(response.status_code, 404)
+
+        # verify
+        url = '/v2/apps/{app_id}/domains'.format(app_id='this-app-does-not-exist')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_manage_domain_invalid_domain(self):
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+        test_domains = [
+            'this_is_an.invalid.domain',
+            'this-is-an.invalid.1',
+            'django.pa--assandbox',
+            'too.looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+            'foo.*.bar.com',
+            '*',
+            'a' * 300,
+            '.'.join(['a'] * 128)
+        ]
+        for domain in test_domains:
+            msg = "failed on \"{}\"".format(domain)
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 400, msg)
+
+    def test_admin_can_add_domains_to_other_apps(self):
+        """If a non-admin user creates an app, an administrator should be able to add
+        domains to it.
+        """
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        url = '/v2/apps/{}/domains'.format(self.app_id)
+        response = self.client.post(url, {'domain': 'example.deis.example.com'})
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_unauthorized_user_cannot_modify_domain(self):
+        """
+        An unauthorized user should not be able to modify other domains.
+
+        Since an unauthorized user should not know about the application at all, these
+        requests should return a 404.
+        """
+        app_id = 'autotest'
+        url = '/v2/apps'
+        response = self.client.post(url, {'id': app_id})
+
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+
+        url = '{}/{}/domains'.format(url, app_id)
+        response = self.client.post(url, {'domain': 'example.com'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_kubernetes_service_failure(self):
+        """
+        Cause an Exception in kubernetes services
+        """
+        self.client.post('/v2/apps', {'id': 'test'})
+
+        # scheduler.get_service exception
+        with mock.patch('scheduler.KubeHTTPClient.get_service') as mock_kube:
+            mock_kube.side_effect = KubeException('Boom!')
+            domain = 'foo.com'
+            url = '/v2/apps/test/domains'
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 503, response.data)
+
+        # scheduler.update_service exception
+        with mock.patch('scheduler.KubeHTTPClient.update_service') as mock_kube:
+            domain = 'foo.com'
+            url = '/v2/apps/test/domains'
+            response = self.client.post(url, {'domain': domain})
+            self.assertEqual(response.status_code, 201, response.data)
+
+            mock_kube.side_effect = KubeException('Boom!')
+            url = '/v2/apps/test/domains/{domain}'.format(domain=domain)
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 503, response.data)

--- a/rootfs/api/tests/deployments/test_hooks.py
+++ b/rootfs/api/tests/deployments/test_hooks.py
@@ -1,0 +1,396 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+from unittest import mock
+from rest_framework.authtoken.models import Token
+
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+RSA_PUBKEY = (
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfQkkUUoxpvcNMkvv7jqnfodgs37M2eBO"
+    "APgLK+KNBMaZaaKB4GF1QhTCMfFhoiTW3rqa0J75bHJcdkoobtTHlK8XUrFqsquWyg3XhsT"
+    "Yr/3RQQXvO86e2sF7SVDJqVtpnbQGc5SgNrHCeHJmf5HTbXSIjCO/AJSvIjnituT/SIAMGe"
+    "Bw0Nq/iSltwYAek1hiKO7wSmLcIQ8U4A00KEUtalaumf2aHOcfjgPfzlbZGP0S0cuBwSqLr"
+    "8b5XGPmkASNdUiuJY4MJOce7bFU14B7oMAy2xacODUs1momUeYtGI9T7X2WMowJaO7tP3Gl"
+    "sgBMP81VfYTfYChAyJpKp2yoP autotest@autotesting comment"
+)
+
+RSA_PUBKEY2 = (
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4xELdubosJ2/bQuiSUyWclVVa71pXpmq"
+    "aXTwfau/XFLgD5yE+TOFbVT22xvEr4AwZqS9w0TBMp4RLfi4pTdjoIK+lau2lDMuEpbF4xg"
+    "PWAveAqKuLcKJbJrZQdo5VWn5//7+M1RHQCPqjeN2iS9I3C8yiPg3mMPT2mKuyZYB9VD3hK"
+    "mhT4xRAsS6vfKZr7CmFHgAmRBqdaU1RetR5nfTj0R5yyAv7Z2BkE8UhUAseFZ0djBs6kzjs"
+    "5ddgM4Gv2Zajs7qVvpVPzZpq3vFB16Q5TMj2YtoYF6UZFFf4u/4KAW8xfYJAFdpNsvh279s"
+    "dJS08nTeElUg6pn83A3hqWX+J testing"
+)
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class HookTest(APITransactionTestCase):
+
+    """Tests API hooks used to trigger actions from external components"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_key_hook(self, mock_requests):
+        """Test fetching keys for an app and a user"""
+
+        # Create app to use
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # give user permission to app
+        url = "/v2/apps/{}/perms".format(app_id)
+        body = {'username': str(self.user)}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # Create key
+        url = '/v2/keys'
+        body = {'id': str(self.user), 'public': RSA_PUBKEY}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        public = response.data['public']
+
+        # Create another keys
+        url = '/v2/keys'
+        body = {'id': str(self.user), 'public': RSA_PUBKEY2}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        public2 = response.data['public']
+
+        # Make sure 404 is returned for a random app
+        url = '/v2/hooks/keys/doesnotexist'
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 404)
+
+        # Test app that exists
+        url = '/v2/hooks/keys/{}'.format(app_id)
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data, {"autotest": [
+            {'key': public, 'fingerprint': '54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5'},
+            {'key': public2, 'fingerprint': '43:fd:22:bc:dc:ca:6a:28:ba:71:4c:18:41:1d:d1:e2'}
+        ]})
+
+        # Test against an app that exist but user does not
+        url = '/v2/hooks/keys/{}/foooooo'.format(app_id)
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 404)
+
+        # Test against an app that exists and user that does
+        url = '/v2/hooks/keys/{}/{}'.format(app_id, str(self.user))
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data, {"autotest": [
+            {'key': public, 'fingerprint': '54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5'},
+            {'key': public2, 'fingerprint': '43:fd:22:bc:dc:ca:6a:28:ba:71:4c:18:41:1d:d1:e2'}
+        ]})
+
+        # Fetch a valid ssh key
+        url = '/v2/hooks/key/54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5'
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data, {
+            "username": str(self.user),
+            "apps": [
+                app_id
+            ]
+        })
+
+        # Fetch an non-existent base64 encoded ssh key
+        url = '/v2/hooks/key/54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:wooooo'
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 404)
+
+        # Fetch an invalid (not encoded) ssh key
+        url = '/v2/hooks/key/nope'
+        response = self.client.get(url, HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 404)
+
+    def test_push_hook(self, mock_requests):
+        """Test creating a Push via the API"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # prepare a push body
+        body = {
+            'sha': 'df1e628f2244b73f9cdf944f880a2b3470a122f4',
+            'fingerprint': '88:25:ed:67:56:91:3d:c6:1b:7f:42:c6:9b:41:24:80',
+            'receive_user': 'autotest',
+            'receive_repo': '{app_id}'.format(**locals()),
+            'ssh_connection': '10.0.1.10 50337 172.17.0.143 22',
+            'ssh_original_command': "git-receive-pack '{app_id}.git'".format(**locals()),
+        }
+        # post a request without the auth header
+        url = "/v2/hooks/push".format(**locals())
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+        # now try with the builder key in the special auth header
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 201, response.data)
+        for k in ('owner', 'app', 'sha', 'fingerprint', 'receive_repo', 'receive_user',
+                  'ssh_connection', 'ssh_original_command'):
+            self.assertIn(k, response.data)
+
+    def test_push_abuse(self, mock_requests):
+        """Test a user pushing to an unauthorized application"""
+        # create a legit app as "autotest"
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # register an evil user
+        username, password = 'eviluser', 'password'
+        first_name, last_name = 'Evil', 'User'
+        email = 'evil@deis.io'
+        submit = {
+            'username': username,
+            'password': password,
+            'first_name': first_name,
+            'last_name': last_name,
+            'email': email,
+        }
+        url = '/v2/auth/register'
+        response = self.client.post(url, submit)
+        self.assertEqual(response.status_code, 201, response.data)
+        # prepare a push body that simulates a git push
+        body = {
+            'sha': 'df1e628f2244b73f9cdf944f880a2b3470a122f4',
+            'fingerprint': '88:25:ed:67:56:91:3d:c6:1b:7f:42:c6:9b:41:24:99',
+            'receive_user': 'eviluser',
+            'receive_repo': '{app_id}'.format(**locals()),
+            'ssh_connection': '10.0.1.10 50337 172.17.0.143 22',
+            'ssh_original_command': "git-receive-pack '{app_id}.git'".format(**locals()),
+        }
+        # try to push as "eviluser"
+        url = "/v2/hooks/push".format(**locals())
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 403)
+
+    def test_build_hook(self, mock_requests):
+        """Test creating a Build via an API Hook"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        build = {'username': 'autotest', 'app': app_id}
+        url = '/v2/hooks/builds'.format(**locals())
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id,
+                'image': '{app_id}:v2'.format(**locals())}
+        # post the build without an auth token
+        self.client.credentials()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 401, response.data)
+        # post the build with the builder auth key
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('release', response.data)
+        self.assertIn('version', response.data['release'])
+
+    def test_build_hook_slug_url(self, mock_requests):
+        """Test creating a slug_url build via an API Hook"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        build = {'username': 'autotest', 'app': app_id}
+        url = '/v2/hooks/builds'.format(**locals())
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id,
+                'image': 'http://example.com/slugs/foo-12345354.tar.gz'}
+
+        # post the build without an auth token
+        self.client.credentials()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 401, response.data)
+
+        # post the build with the builder auth key
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('release', response.data)
+        self.assertIn('version', response.data['release'])
+
+    def test_build_hook_procfile(self, mock_requests):
+        """Test creating a Procfile build via an API Hook"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        build = {'username': 'autotest', 'app': app_id}
+        url = '/v2/hooks/builds'.format(**locals())
+        PROCFILE = {'web': 'node server.js', 'worker': 'node worker.js'}
+        SHA = 'ecdff91c57a0b9ab82e89634df87e293d259a3aa'
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id,
+                'image': '{app_id}:v2'.format(**locals()),
+                'sha': SHA,
+                'procfile': PROCFILE}
+
+        # post the build with the builder auth key
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('release', response.data)
+        self.assertIn('version', response.data['release'])
+        # make sure build fields were populated
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('results', response.data)
+        build = response.data['results'][0]
+        self.assertEqual(build['sha'], SHA)
+        self.assertEqual(build['procfile'], PROCFILE)
+        # test listing/retrieving container info
+        url = "/v2/apps/{app_id}/pods/web".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'web')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
+
+        # post the build without an auth token
+        self.client.credentials()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 401, response.data)
+
+    def test_build_hook_dockerfile(self, mock_requests):
+        """Test creating a Dockerfile build via an API Hook"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        build = {'username': 'autotest', 'app': app_id}
+        url = '/v2/hooks/builds'.format(**locals())
+        SHA = 'ecdff91c57a0b9ab82e89634df87e293d259a3aa'
+        DOCKERFILE = """FROM busybox
+        CMD /bin/true"""
+
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id,
+                'image': '{app_id}:v2'.format(**locals()),
+                'sha': SHA,
+                'dockerfile': DOCKERFILE}
+        # post the build with the builder auth key
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('release', response.data)
+        self.assertIn('version', response.data['release'])
+        # make sure build fields were populated
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('results', response.data)
+        build = response.data['results'][0]
+        self.assertEqual(build['sha'], SHA)
+        self.assertEqual(build['dockerfile'], DOCKERFILE)
+        # test default container
+        url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        container = response.data['results'][0]
+        self.assertEqual(container['type'], 'cmd')
+        self.assertEqual(container['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+
+        # post the build without an auth token
+        self.client.credentials()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 401, response.data)
+
+    def test_config_hook(self, mock_requests):
+        """Test reading Config via an API Hook"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('values', response.data)
+        values = response.data['values']
+        # prepare the config hook
+        config = {'username': 'autotest', 'app': app_id}
+        url = '/v2/hooks/config'.format(**locals())
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id}
+        # post without an auth token
+        self.client.credentials()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 401, response.data)
+        # post with the builder auth key
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn('values', response.data)
+        self.assertEqual(values, response.data['values'])
+
+    def test_admin_can_hook(self, mock_requests):
+        """Administrator should be able to create build hooks on non-admin apps.
+        """
+        """Test creating a Push via the API"""
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # prepare a push body
+        DOCKERFILE = """
+        FROM busybox
+        CMD /bin/true
+        """
+        body = {'receive_user': 'autotest',
+                'receive_repo': app_id,
+                'image': '{app_id}:v2'.format(**locals()),
+                'sha': 'ecdff91c57a0b9ab82e89634df87e293d259a3aa',
+                'dockerfile': DOCKERFILE}
+        url = '/v2/hooks/builds'
+        response = self.client.post(url, body,
+                                    HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['release']['version'], 2)

--- a/rootfs/api/tests/deployments/test_pods.py
+++ b/rootfs/api/tests/deployments/test_pods.py
@@ -1,0 +1,858 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+import json
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+from unittest import mock
+from rest_framework.authtoken.models import Token
+from test.support import EnvironmentVarGuard
+
+from api.models import App, Build, Release
+from scheduler import KubeException
+
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class PodTest(APITransactionTestCase):
+    """Tests creation of pods on nodes"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_container_api_heroku(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # should start with zero
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        # test setting one proc type at a time
+        body = {'web': 4}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        body = {'worker': 2}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 6)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        # ensure the structure field is up-to-date
+        self.assertEqual(response.data['structure']['web'], 4)
+        self.assertEqual(response.data['structure']['worker'], 2)
+
+        # test listing/retrieving container info
+        url = "/v2/apps/{app_id}/pods/web".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['count'], 4)
+        self.assertEqual(len(response.data['results']), 4)
+
+        name = response.data['results'][0]['name']
+        url = "/v2/apps/{app_id}/pods/web/{name}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['name'], name)
+
+        # scale down
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        # test setting two proc types at a time
+        body = {'web': 2, 'worker': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 3)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        # ensure the structure field is up-to-date
+        self.assertEqual(response.data['structure']['web'], 2)
+        self.assertEqual(response.data['structure']['worker'], 1)
+
+        # scale down to 0
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 0, 'worker': 0}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_container_api_docker(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # should start with zero
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'dockerfile': "FROM busybox\nCMD /bin/true"
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'cmd': 6}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 6)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        # test listing/retrieving container info
+        url = "/v2/apps/{app_id}/pods/cmd".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 6)
+
+        # scale down
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'cmd': 3}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 3)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        # scale down to 0
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'cmd': 0}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_release(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # should start with zero
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['release'], 'v2')
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        # a web proctype must exist on the second build or else the container will be removed
+        body = {
+            'image': 'autotest/example',
+            'procfile': {
+                'web': 'echo hi'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['release'], 'v3')
+
+        # post new config
+        url = "/v2/apps/{app_id}/config".format(**locals())
+        body = {'values': json.dumps({'KEY': 'value'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['release'], 'v4')
+
+    def test_container_errors(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # create a release so we can scale
+        app = App.objects.get(id=app_id)
+        user = User.objects.get(username='autotest')
+        build = Build.objects.create(owner=user, app=app, image="qwerty")
+
+        # create an initial release
+        Release.objects.create(
+            version=2,
+            owner=user,
+            app=app,
+            config=app.config_set.latest(),
+            build=build
+        )
+
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 'not_an_int'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': "Invalid scaling format: invalid literal for "
+                                                   "int() with base 10: 'not_an_int'"})
+        body = {'invalid': 1}
+        response = self.client.post(url, body)
+        self.assertContains(response, 'Container type invalid', status_code=400)
+
+    def test_container_str(self, mock_requests):
+        """Test the text representation of a container."""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 4, 'worker': 2}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # should start with zero
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 6)
+        pods = response.data['results']
+        for pod in pods:
+            self.assertIn(pod['type'], ['web', 'worker'])
+            self.assertEqual(pod['release'], 'v2')
+            # pod name is auto generated so use regex
+            if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+                self.assertRegex(pod['name'], app_id + '-(worker|web)-[0-9]{8,10}-[a-z0-9]{5}')
+            else:
+                self.assertRegex(pod['name'], app_id + '-v2-(worker|web)-[a-z0-9]{5}')
+
+    def test_pod_command_format(self, mock_requests):
+        # regression test for https://github.com/deis/deis/pull/1285
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+
+        # verify that the app._get_command property got formatted
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+
+        pod = response.data['results'][0]
+        self.assertEqual(pod['type'], 'web')
+        self.assertEqual(pod['release'], 'v2')
+        # pod name is auto generated so use regex
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(pod['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(pod['name'], app_id + '-v2-web-[a-z0-9]{5}')
+
+        # verify commands
+        data = App.objects.get(id=app_id)
+        self.assertNotIn('{c_type}', data._get_command('web'))
+
+    def test_scale_errors(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # should start with zero
+        url = "/v2/apps/{app_id}/pods".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data['results']), 0)
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # scale to a negative number
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': -1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {"detail": "Invalid scaling format: "
+                                         "['Must be greater than or equal to zero']"})
+
+        # scale to something other than a number
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 'one'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # scale to something other than a number
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': [1]}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        # scale up to an integer as a sanity check
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        with mock.patch('scheduler.KubeHTTPClient.scale') as mock_kube:
+            mock_kube.side_effect = KubeException('Boom!')
+            url = "/v2/apps/{app_id}/scale".format(**locals())
+            response = self.client.post(url, {'web': 10})
+            self.assertEqual(response.status_code, 503, response.data)
+
+    def test_admin_can_manage_other_pods(self, mock_requests):
+        """If a non-admin user creates a container, an administrator should be able to
+        manage it.
+        """
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # login as admin, scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 4, 'worker': 2}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+    def test_scale_without_build_should_error(self, mock_requests):
+        """A user should not be able to scale processes unless a build is present."""
+        app_id = 'autotest'
+        url = '/v2/apps'
+        body = {'cluster': 'autotest', 'id': app_id}
+        response = self.client.post(url, body)
+
+        url = '/v2/apps/{app_id}/scale'.format(**locals())
+        body = {'web': '1'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'No build associated with this release'})
+
+    def test_command_good(self, mock_requests):
+        """Test the default command for each container workflow"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+        user = User.objects.get(username='autotest')
+
+        # Heroku Buildpack app
+        build = Build.objects.create(
+            owner=user,
+            app=app,
+            image="qwerty",
+            procfile={
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            },
+            sha='african-swallow',
+            dockerfile=''
+        )
+
+        # create an initial release
+        Release.objects.create(
+            version=2,
+            owner=user,
+            app=app,
+            config=app.config_set.latest(),
+            build=build
+        )
+
+        # use `start web` for backwards compatibility with slugrunner
+        self.assertEqual(app._get_command('web'), 'start web')
+        self.assertEqual(app._get_command('worker'), 'start worker')
+
+        # switch to docker image app
+        build.sha = ''
+        build.save()
+        self.assertEqual(app._get_command('web'), "bash -c 'node server.js'")
+
+        # switch to dockerfile app
+        build.sha = 'european-swallow'
+        build.dockerfile = 'dockerdockerdocker'
+        build.save()
+        self.assertEqual(app._get_command('web'), "bash -c 'node server.js'")
+        self.assertEqual(app._get_command('cmd'), '')
+
+        # ensure we can override the cmd process type in a Procfile
+        build.procfile['cmd'] = 'node server.js'
+        build.save()
+        self.assertEqual(app._get_command('cmd'), "bash -c 'node server.js'")
+        self.assertEqual(app._get_command('worker'), "bash -c 'node worker.js'")
+
+        # for backwards compatibility if no Procfile is supplied
+        build.procfile = {}
+        build.save()
+        self.assertEqual(app._get_command('worker'), 'start worker')
+
+    def test_run_command_good(self, mock_requests):
+        """Test the run command for each container workflow"""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+
+        # dockerfile + procfile worflow
+        build = Build.objects.create(
+            owner=self.user,
+            app=app,
+            image="qwerty",
+            procfile={
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            },
+            dockerfile='foo',
+            sha='somereallylongsha'
+        )
+
+        # create an initial release
+        Release.objects.create(
+            version=2,
+            owner=self.user,
+            app=app,
+            config=app.config_set.latest(),
+            build=build
+        )
+
+        # create a run pod
+        url = "/v2/apps/{app_id}/run".format(**locals())
+        body = {'command': 'echo hi'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
+        self.assertEqual(entrypoint, '/bin/bash')
+
+        # docker image workflow
+        build.dockerfile = ''
+        build.sha = ''
+        build.save()
+        url = "/v2/apps/{app_id}/run".format(**locals())
+        body = {'command': 'echo hi'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
+        self.assertEqual(entrypoint, '/bin/bash')
+
+        # procfile workflow
+        build.sha = 'somereallylongsha'
+        build.save()
+        url = "/v2/apps/{app_id}/run".format(**locals())
+        body = {'command': 'echo hi'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
+        self.assertEqual(entrypoint, '/runner/init')
+
+    def test_run_not_fail_on_debug(self, mock_requests):
+        """
+        do a run with DEIS_DEBUG on - https://github.com/deis/controller/issues/583
+        """
+        env = EnvironmentVarGuard()
+        env['DEIS_DEBUG'] = 'true'
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+
+        # dockerfile + procfile worflow
+        build = Build.objects.create(
+            owner=self.user,
+            app=app,
+            image="qwerty",
+            procfile={
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            },
+            dockerfile='foo',
+            sha='somereallylongsha'
+        )
+
+        # create an initial release
+        Release.objects.create(
+            version=2,
+            owner=self.user,
+            app=app,
+            config=app.config_set.latest(),
+            build=build
+        )
+
+        # create a run pod
+        url = "/v2/apps/{app_id}/run".format(**locals())
+        body = {'command': 'echo hi'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = App.objects.get(id=app_id)
+        entrypoint, _ = data._get_command_run('echo hi')
+        self.assertEqual(entrypoint, '/bin/bash')
+
+    def test_scaling_does_not_add_run_proctypes_to_structure(self, mock_requests):
+        """Test that app info doesn't show transient "run" proctypes."""
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+        user = User.objects.get(username='autotest')
+
+        # dockerfile + procfile worflow
+        build = Build.objects.create(
+            owner=user,
+            app=app,
+            image="qwerty",
+            procfile={
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            },
+            dockerfile='foo',
+            sha='somereallylongsha'
+        )
+
+        # create an initial release
+        release = Release.objects.create(
+            version=2,
+            owner=user,
+            app=app,
+            config=app.config_set.latest(),
+            build=build
+        )
+
+        # create a run pod
+        url = "/v2/apps/{app_id}/run".format(**locals())
+        body = {'command': 'echo hi'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        # scale up
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 3}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # test that "run" proctype isn't in the app info returned
+        url = "/v2/apps/{app_id}".format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertNotIn('run', response.data['structure'])
+
+    def test_scale_with_unauthorized_user_returns_403(self, mock_requests):
+        """An unauthorized user should not be able to access an app's resources.
+
+        If an unauthorized user is trying to scale an app he or she does not have access to, it
+        should return a 403.
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})
+        }
+        response = self.client.post(url, body)
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+
+        # scale up with unauthorized user
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 4}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 403)
+
+    def test_modified_procfile_from_build_removes_pods(self, mock_requests):
+        """
+        When a new procfile is posted which removes a certain process type, deis should stop the
+        existing pods.
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        build_url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(build_url, body)
+
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 4}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(build_url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # make sure no pods are web
+        application = App.objects.get(id=app_id)
+        pods = application.list_pods(type='web')
+        self.assertEqual(len(pods), 0)
+
+    def test_restart_pods(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # post a new build
+        build_url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': json.dumps({
+                'web': 'node server.js',
+                'worker': 'node worker.js'
+            })
+        }
+        response = self.client.post(build_url, body)
+
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'web': 4, 'worker': 8}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 204, response.data)
+
+        # setup app object
+        application = App.objects.get(id=app_id)
+
+        # restart all pods
+        response = self.client.post('/v2/apps/{}/pods/restart'.format(app_id))
+        self.assertEqual(response.status_code, 200, response.data)
+        # Compare restarted pods to all pods
+        self.assertEqual(len(response.data), 12)
+
+        # restart only the workers
+        response = self.client.post('/v2/apps/{}/pods/worker/restart'.format(app_id))
+        self.assertEqual(response.status_code, 200, response.data)
+        # Compare restarted pods to only worker pods
+        self.assertEqual(len(response.data), 8)
+
+        # restart only the web
+        response = self.client.post('/v2/apps/{}/pods/web/restart'.format(app_id))
+        self.assertEqual(response.status_code, 200, response.data)
+        # Compare restarted pods to only worker pods
+        self.assertEqual(len(response.data), 4)
+
+        # restart only one of the web pods
+        pods = application.list_pods(type='web')
+        self.assertEqual(len(pods), 4)
+
+        pod = pods.pop()
+        response = self.client.post('/v2/apps/{}/pods/web/{}/restart'.format(app_id, pod['name']))
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['type'], 'web')
+
+        # restart only one web port but using the short name of web-asdfg
+        name = 'web-' + pod['name'].split('-').pop()
+        response = self.client.post('/v2/apps/{}/pods/web/{}/restart'.format(app_id, name))
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['type'], 'web')
+
+    def test_list_pods_failure(self, mock_requests):
+        """
+        Listing all available pods exceptions
+        """
+
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        with mock.patch('scheduler.KubeHTTPClient.get_pod') as kube_pod:
+            with mock.patch('scheduler.KubeHTTPClient.get_pods') as kube_pods:
+                kube_pod.side_effect = KubeException('boom!')
+                kube_pods.side_effect = KubeException('boom!')
+                url = "/v2/apps/{app_id}/pods".format(**locals())
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 503, response.data)

--- a/rootfs/api/tests/deployments/test_release.py
+++ b/rootfs/api/tests/deployments/test_release.py
@@ -1,0 +1,395 @@
+"""
+Unit tests for the Deis api app.
+
+Run the tests with "./manage.py test api"
+"""
+
+
+import json
+import uuid
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+from unittest import mock
+from rest_framework.authtoken.models import Token
+
+from api.models import App, Release
+from scheduler import KubeHTTPException
+from api.tests import adapter
+from api.tests import mock_port
+import requests_mock
+
+
+@override_settings(DEIS_KUBERNETES_DEPLOYMENTS='1')
+@requests_mock.Mocker(real_http=True, adapter=adapter)
+@mock.patch('api.models.release.publish_release', lambda *args: None)
+@mock.patch('api.models.release.docker_get_port', mock_port)
+class ReleaseTest(APITransactionTestCase):
+
+    """Tests push notification from build system"""
+
+    fixtures = ['tests.json']
+
+    def setUp(self):
+        self.user = User.objects.get(username='autotest')
+        self.token = Token.objects.get(user=self.user).key
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+    def tearDown(self):
+        # make sure every test has a clean slate for k8s mocking
+        cache.clear()
+
+    def test_release(self, mock_requests):
+        """
+        Test that a release is created when an app is created, and
+        that updating config or build or triggers a new release
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # check that updating config rolls a new release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('NEW_URL1', response.data['values'])
+        # check to see that an initial release was created
+        url = '/v2/apps/{app_id}/releases'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        # account for the config release as well
+        self.assertEqual(response.data['count'], 2)
+        url = '/v2/apps/{app_id}/releases/v1'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        release1 = response.data
+        self.assertIn('config', response.data)
+        self.assertIn('build', response.data)
+        self.assertEqual(release1['version'], 1)
+        # check to see that a new release was created
+        url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        release2 = response.data
+        self.assertNotEqual(release1['uuid'], release2['uuid'])
+        self.assertNotEqual(release1['config'], release2['config'])
+        self.assertEqual(release1['build'], release2['build'])
+        self.assertEqual(release2['version'], 2)
+        # check that updating the build rolls a new release
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        build_config = json.dumps({'PATH': 'bin:/usr/local/bin:/usr/bin:/bin'})
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+        # check to see that a new release was created
+        url = '/v2/apps/{app_id}/releases/v3'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        release3 = response.data
+        self.assertNotEqual(release2['uuid'], release3['uuid'])
+        self.assertNotEqual(release2['build'], release3['build'])
+        self.assertEqual(release3['version'], 3)
+        # check that we can fetch a previous release
+        url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        release2 = response.data
+        self.assertNotEqual(release2['uuid'], release3['uuid'])
+        self.assertNotEqual(release2['build'], release3['build'])
+        self.assertEqual(release2['version'], 2)
+        # disallow post/put/patch/delete
+        url = '/v2/apps/{app_id}/releases'.format(**locals())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 405, response.content)
+        return release3
+
+    def test_response_data(self, mock_requests):
+        body = {'id': 'test'}
+        response = self.client.post('/v2/apps', body,)
+        body = {'values': json.dumps({'NEW_URL': 'http://localhost:8080/'})}
+        config_response = self.client.post('/v2/apps/test/config', body)
+        url = '/v2/apps/test/releases/v2'
+        response = self.client.get(url)
+        for key in response.data.keys():
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'build', 'config',
+                                'summary', 'version'])
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'build': None,
+            'config': uuid.UUID(config_response.data['uuid']),
+            'summary': '{} added NEW_URL'.format(self.user.username),
+            'version': 2
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
+    def test_release_rollback(self, mock_requests):
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+        # try to rollback with only 1 release extant, expecting 400
+        url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'version cannot be below 0'})
+        self.assertEqual(response.get('content-type'), 'application/json')
+        # update the build to roll a new release
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        # update config to roll another release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        # create another release with a different build
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        body = {'image': 'autotest/example:canary'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        # rollback and check to see that a 5th release was created
+        # with the build and config of release #3
+        url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(Release.objects.count(), 5)
+        release1 = Release.objects.get(app=app, version=1)
+        release2 = Release.objects.get(app=app, version=2)
+        release3 = Release.objects.get(app=app, version=3)
+        release4 = Release.objects.get(app=app, version=4)
+        release5 = Release.objects.get(app=app, version=5)
+        # verify the rollback to v3
+        self.assertNotEqual(release5.uuid, release3.uuid)
+        self.assertNotEqual(release5.build, release4.build)
+        self.assertEqual(release5.build, release3.build)
+        self.assertEqual(release5.config.values, release3.config.values)
+        # double-check to see that the current build and config is the same as v3
+        self.assertEqual(release5.build.image, 'autotest/example')
+        self.assertEqual(release5.config.values, {'NEW_URL1': 'http://localhost:8080/'})
+        # try to rollback to v1 and verify that the rollback failed
+        # (v1 is an initial release with no build)
+        url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
+        body = {'version': 1}
+        response = self.client.post(url, body)
+        self.assertContains(response, 'Cannot roll back to initial release.', status_code=400)
+        # roll back to v2 so we can verify config gets rolled back too
+        url = "/v2/apps/{app_id}/releases/rollback/".format(**locals())
+        body = {'version': 2}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(Release.objects.count(), 6)
+        release6 = Release.objects.get(app=app, version=6)
+        self.assertEqual(release6.build.image, 'autotest/example')
+        self.assertEqual(release6.config.values, {})
+
+    def test_release_str(self, mock_requests):
+        """Test the text representation of a release."""
+        release3 = self.test_release()
+        release = Release.objects.get(uuid=release3['uuid'])
+        self.assertEqual(str(release), "{}-v3".format(release3['app']))
+
+    def test_release_summary(self, mock_requests):
+        """Test the text summary of a release."""
+        release3 = self.test_release()
+        release = Release.objects.get(uuid=release3['uuid'])
+        # check that the release has push and env change messages
+        self.assertIn('autotest deployed ', release.summary)
+
+    def test_admin_can_create_release(self, mock_requests):
+        """If a non-user creates an app, an admin should be able to create releases."""
+        user = User.objects.get(username='autotest2')
+        token = Token.objects.get(user=user).key
+        url = '/v2/apps'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        # check that updating config rolls a new release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('NEW_URL1', response.data['values'])
+        # check to see that an initial release was created
+        url = '/v2/apps/{app_id}/releases'.format(**locals())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, response.data)
+        # account for the config release as well
+        self.assertEqual(response.data['count'], 2)
+
+    def test_unauthorized_user_cannot_modify_release(self, mock_requests):
+        """
+        An unauthorized user should not be able to modify other releases.
+
+        Since an unauthorized user should not know about the application at all, these
+        requests should return a 404.
+        """
+        app_id = 'autotest'
+        base_url = '/v2/apps'
+        body = {'id': app_id}
+        response = self.client.post(base_url, body)
+
+        # push a new build
+        url = '{base_url}/{app_id}/builds'.format(**locals())
+        body = {'image': 'test'}
+        response = self.client.post(url, body)
+
+        # update config to roll a new release
+        url = '{base_url}/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+
+        # try to rollback
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + unauthorized_token)
+        url = '{base_url}/{app_id}/releases/rollback/'.format(**locals())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_release_rollback_failure(self, mock_requests):
+        """
+        Cause an Exception in app.deploy to cause a release.delete
+        """
+        body = {'id': 'test'}
+        self.client.post('/v2/apps', body)
+
+        # deploy app to get a build
+        url = "/v2/apps/test/builds"
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['image'], body['image'])
+
+        # update config to roll a new release
+        url = '/v2/apps/test/config'
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # update config to roll a new release
+        url = '/v2/apps/test/config'
+        body = {'values': json.dumps({'NEW_URL2': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        # app.deploy exception
+        with mock.patch('api.models.App.deploy') as mock_deploy:
+            mock_deploy.side_effect = Exception('Boom!')
+            url = "/v2/apps/test/releases/rollback/"
+            body = {'version': 2}
+            response = self.client.post(url, body)
+            self.assertEqual(response.status_code, 400, response.data)
+
+        # app.deploy exception followed by a KubeHTTPException of 404
+        with mock.patch('api.models.App.deploy') as mock_deploy:
+            mock_deploy.side_effect = Exception('Boom!')
+            with mock.patch('api.models.Release._delete_release_in_scheduler') as mock_kube:
+                # instead of full request mocking, fake it out in a simple way
+                class Response(object):
+                    def json(self):
+                        return '{}'
+
+                response = Response()
+                response.status_code = 404
+                response.reason = "Not Found"
+                kube_exception = KubeHTTPException(response, 'big boom')
+                mock_kube.side_effect = kube_exception
+
+                url = "/v2/apps/test/releases/rollback/"
+                body = {'version': 2}
+                response = self.client.post(url, body)
+                self.assertEqual(response.status_code, 400, response.data)
+
+    def test_release_unset_config(self, mock_requests):
+        """
+        Test that a release is created when an app is created, a config can be
+        set and then unset without causing a 409 (conflict)
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check that updating config rolls a new release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'cpu': json.dumps({'cmd': None})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 422, response.data)
+
+    def test_release_no_change(self, mock_requests):
+        """
+        Test that a release is created when an app is created, and
+        then has 2 identical config set, causing a 409 as there was
+        no change
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+
+        # check that updating config rolls a new release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('NEW_URL1', response.data['values'])
+
+        # trigger identical release
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 409, response.data)
+
+    def test_release_get_port(self, mock_requests):
+        """
+        Test that get_port always returns the proper value.
+        """
+        url = '/v2/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201, response.data)
+        app_id = response.data['id']
+        app = App.objects.get(id=app_id)
+
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        body = {'sha': '123456', 'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        release = app.release_set.latest()
+
+        # when app is not routable, then it still return 5000
+        self.assertEqual(release.get_port(), 5000)
+
+        # when a buildpack type, default to 5000
+        self.assertEqual(release.get_port(), 5000)
+
+        # switch to a dockerfile app or else it'll automatically default to 5000
+        url = '/v2/apps/{app_id}/builds'.format(**locals())
+        body = {'image': 'autotest/example'}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+
+        url = '/v2/apps/{app_id}/config'.format(**locals())
+        body = {'values': json.dumps({'PORT': '8080'})}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)
+        release = app.release_set.latest()
+
+        # check that the port number returned is an int, not a string
+        self.assertEqual(release.get_port(), 8080)
+
+        # TODO(bacongobbler): test dockerfile ports

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -123,7 +123,10 @@ class BuildTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
 
         # start with a new app
         url = '/v2/apps'
@@ -148,7 +151,10 @@ class BuildTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
 
         # start with a new app
         url = '/v2/apps'
@@ -177,7 +183,10 @@ class BuildTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
 
         # start with a new app
         url = '/v2/apps'
@@ -206,7 +215,10 @@ class BuildTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'web')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
 
     def test_build_str(self, mock_requests):
         """Test the text representation of a build."""

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -278,7 +278,10 @@ class HookTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'web')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-web-[a-z0-9]{5}')
 
         # post the build without an auth token
         self.client.credentials()
@@ -325,7 +328,10 @@ class HookTest(APITransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(container['name'], app_id + '-cmd-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(container['name'], app_id + '-v2-cmd-[a-z0-9]{5}')
 
         # post the build without an auth token
         self.client.credentials()

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -5,6 +5,7 @@ Run the tests with "./manage.py test api"
 """
 import json
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from rest_framework.test import APITransactionTestCase
@@ -339,7 +340,10 @@ class PodTest(APITransactionTestCase):
             self.assertIn(pod['type'], ['web', 'worker'])
             self.assertEqual(pod['release'], 'v2')
             # pod name is auto generated so use regex
-            self.assertRegex(pod['name'], app_id + '-v2-(worker|web)-[a-z0-9]{5}')
+            if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+                self.assertRegex(pod['name'], app_id + '-(worker|web)-[0-9]{8,10}-[a-z0-9]{5}')
+            else:
+                self.assertRegex(pod['name'], app_id + '-v2-(worker|web)-[a-z0-9]{5}')
 
     def test_pod_command_format(self, mock_requests):
         # regression test for https://github.com/deis/deis/pull/1285
@@ -377,7 +381,10 @@ class PodTest(APITransactionTestCase):
         self.assertEqual(pod['type'], 'web')
         self.assertEqual(pod['release'], 'v2')
         # pod name is auto generated so use regex
-        self.assertRegex(pod['name'], app_id + '-v2-web-[a-z0-9]{5}')
+        if settings.DEIS_KUBERNETES_DEPLOYMENTS:
+            self.assertRegex(pod['name'], app_id + '-web-[0-9]{8,10}-[a-z0-9]{5}')
+        else:
+            self.assertRegex(pod['name'], app_id + '-v2-web-[a-z0-9]{5}')
 
         # verify commands
         data = App.objects.get(id=app_id)


### PR DESCRIPTION
TODO:
- [x] There is one flakey tests for Deployments (mock related)
- [x] [docs](https://github.com/deis/workflow)
- [x] [e2e](https://github.com/deis/workflow-e2e)

Closes #19 
Requires deis/workflow-e2e#251
Requires deis/workflow#369

This adds Deployment object support (replaces ReplicationController) when a feature flag is enabled. This can be done by either settings a global ENV Var on the Controller or setting a config per app. The variable is `DEIS_KUBERNETES_DEPLOYMENTS=1`

A few new features (Deployments only) have been introduced or specifically expose Deployment functionalities:
* `KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT` (global and per app setting) specifies how many revisions (ReplicaSets) to keep
* Stop concurrent deployments (triggered by push, pull, config:set and so on)

If Deployments is enabled on an existing app then a whole new copy will be spun up (behind the scenes) as Deployment and then the old ReplicationController is spun down. This is a one way conversion.

Note that pod naming has changed due to how Deployments adds a hash to the name, among other things.