### PR TITLE
fix(scheduler): cast port to an int from environment

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -161,11 +161,11 @@ class Release(UuidAuditedModel):
                     return 5000
 
                 # User provided PORT
-                return envs.get('PORT')
+                return int(envs.get('PORT'))
 
             # If the user provides PORT
             if envs.get('PORT', None):
-                return envs.get('PORT')
+                return int(envs.get('PORT'))
 
             # discover port from docker image
             port = docker_get_port(self.image, deis_registry, creds)


### PR DESCRIPTION
Kubernetes requires the port number to be an integer or else it assumes that it is a named port.

fixes #856