### PR TITLE
fix(release): return port from get_port for non-routable process types

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -385,7 +385,7 @@ class App(UuidAuditedModel):
             # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
             routable = True if scale_type in ['web', 'cmd'] else False
             # fetch application port and inject into ENV Vars as needed
-            port = release.get_port(routable)
+            port = release.get_port()
             if port:
                 envs['PORT'] = port
 
@@ -440,7 +440,7 @@ class App(UuidAuditedModel):
             # http://docs.deis.io/en/latest/using_deis/process-types/#web-vs-cmd-process-types
             routable = True if scale_type in ['web', 'cmd'] else False
             # fetch application port and inject into ENV vars as needed
-            port = release.get_port(routable)
+            port = release.get_port()
             if port:
                 envs['PORT'] = port
 

--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -134,7 +134,7 @@ class Release(UuidAuditedModel):
         deis_registry = bool(self.build.source_based)
         publish_release(source_image, self.image, deis_registry, self.get_registry_auth())
 
-    def get_port(self, routable=False):
+    def get_port(self):
         """
         Get application port for a given release. If pulling from private registry
         then use default port or read from ENV var, otherwise attempt to pull from
@@ -144,11 +144,6 @@ class Release(UuidAuditedModel):
             deis_registry = bool(self.build.source_based)
             envs = self.config.values
             creds = self.get_registry_auth()
-
-            port = None
-            # Only care about port for routable application
-            if not routable:
-                return port
 
             if self.build.type == "buildpack":
                 self.app.log('buildpack type detected. Defaulting to $PORT 5000')

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -369,11 +369,11 @@ class ReleaseTest(APITransactionTestCase):
         self.assertEqual(response.status_code, 201, response.data)
         release = app.release_set.latest()
 
-        # when app is not routable, returns None
-        self.assertEqual(release.get_port(), None)
+        # when app is not routable, then it still return 5000
+        self.assertEqual(release.get_port(), 5000)
 
         # when a buildpack type, default to 5000
-        self.assertEqual(release.get_port(routable=True), 5000)
+        self.assertEqual(release.get_port(), 5000)
 
         # switch to a dockerfile app or else it'll automatically default to 5000
         url = '/v2/apps/{app_id}/builds'.format(**locals())
@@ -388,6 +388,6 @@ class ReleaseTest(APITransactionTestCase):
         release = app.release_set.latest()
 
         # check that the port number returned is an int, not a string
-        self.assertEqual(release.get_port(routable=True), 8080)
+        self.assertEqual(release.get_port(), 8080)
 
         # TODO(bacongobbler): test dockerfile ports


### PR DESCRIPTION
Env Vars are stored in a Secret, where there is 1 secret per Release. This causes a situation where non-web/cmd proc types will overwrite the Secret data during deploys.
This is the only way possible (for now) since env vars are per Release and not per proc type