### PR TITLE
fix(healthchecks): when migrating from old healthchecks also add in readiness probe

### DIFF
--- a/rootfs/api/models/config.py
+++ b/rootfs/api/models/config.py
@@ -56,6 +56,20 @@ class Config(UuidAuditedModel):
             }
         }
 
+        self.healthcheck['readinessProbe'] = {
+            'initialDelaySeconds': delay,
+            'timeoutSeconds': timeout,
+            'periodSeconds': period_seconds,
+            'successThreshold': success_threshold,
+            'failureThreshold': failure_threshold,
+            'httpGet': {
+                'path': path,
+            }
+        }
+
+        # Unset all the old values
+        self.values = {k: v for k, v in self.values.items() if not k.startswith('HEALTHCHECK_')}
+
     def set_registry(self):
         # lower case all registry options for consistency
         self.registry = {key.lower(): value for key, value in self.registry.copy().items()}

--- a/rootfs/api/tests/deployments/test_config.py
+++ b/rootfs/api/tests/deployments/test_config.py
@@ -773,39 +773,6 @@ class ConfigTest(APITransactionTestCase):
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
 
-    def test_healthchecks(self, mock_requests):
-        """
-        Test that healthchecks can be applied
-        """
-        response = self.client.post('/v2/apps')
-        self.assertEqual(response.status_code, 201, response.data)
-        app_id = response.data['id']
-
-        # Set a healthcheck option before URL is around (URL is required for full setting)
-        resp = self.client.post(
-            '/v2/apps/{app_id}/config'.format(**locals()),
-            {'values': json.dumps({'HEALTHCHECK_INITIAL_DELAY': '25'})}
-        )
-        self.assertEqual(resp.status_code, 201, response.data)
-        self.assertIn('HEALTHCHECK_INITIAL_DELAY', resp.data['values'])
-        self.assertEqual(resp.data['values']['HEALTHCHECK_INITIAL_DELAY'], '25')
-
-        # Set healthcheck URL to get defaults set
-        resp = self.client.post(
-            '/v2/apps/{app_id}/config'.format(**locals()),
-            {'values': json.dumps({'HEALTHCHECK_URL': '/health'})}
-        )
-        self.assertEqual(resp.status_code, 201, response.data)
-        self.assertIn('HEALTHCHECK_URL', resp.data['values'])
-        self.assertEqual(resp.data['values']['HEALTHCHECK_URL'], '/health')
-
-        # post a new build
-        response = self.client.post(
-            "/v2/apps/{app_id}/builds".format(**locals()),
-            {'image': 'quay.io/autotest/example'}
-        )
-        self.assertEqual(response.status_code, 201, response.data)
-
     def test_healthchecks_validations(self, mock_requests):
         """
         Test that healthchecks validations work
@@ -929,11 +896,21 @@ class ConfigTest(APITransactionTestCase):
             {'values': json.dumps({'HEALTHCHECK_URL': '/health'})}
         )
         self.assertEqual(response.status_code, 201, response.data)
-        self.assertIn('HEALTHCHECK_URL', response.data['values'])
-        self.assertEqual(response.data['values']['HEALTHCHECK_URL'], '/health')
+        # this gets migrated to the new healtcheck format
+        self.assertNotIn('HEALTHCHECK_URL', response.data['values'])
         # legacy defaults
         expected = {
             'livenessProbe': {
+                'initialDelaySeconds': 50,
+                'timeoutSeconds': 50,
+                'periodSeconds': 10,
+                'successThreshold': 1,
+                'failureThreshold': 3,
+                'httpGet': {
+                    'path': '/health'
+                }
+            },
+            'readinessProbe': {
                 'initialDelaySeconds': 50,
                 'timeoutSeconds': 50,
                 'periodSeconds': 10,
@@ -951,6 +928,7 @@ class ConfigTest(APITransactionTestCase):
             '/v2/apps/{app.id}/config'.format(**locals()),
             {
                 'values': json.dumps({
+                    'HEALTHCHECK_URL': '/health',
                     'HEALTHCHECK_INITIAL_DELAY': '25',
                     'HEALTHCHECK_TIMEOUT': '10',
                     'HEALTHCHECK_PERIOD_SECONDS': '5',
@@ -959,8 +937,8 @@ class ConfigTest(APITransactionTestCase):
             }
         )
         self.assertEqual(response.status_code, 201, response.data)
-        self.assertIn('HEALTHCHECK_INITIAL_DELAY', response.data['values'])
-        self.assertEqual(response.data['values']['HEALTHCHECK_INITIAL_DELAY'], '25')
+        # this gets migrated to the new healtcheck format
+        self.assertNotIn('HEALTHCHECK_INITIAL_DELAY', response.data['values'])
         expected['livenessProbe'] = {
             'initialDelaySeconds': 25,
             'timeoutSeconds': 10,
@@ -971,5 +949,6 @@ class ConfigTest(APITransactionTestCase):
                 'path': '/health'
             }
         }
+        expected['readinessProbe'] = expected['livenessProbe']
         actual = app.config_set.latest().healthcheck
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Also get the max() between liveness and readiness initial seconds delay to use in deploy timeout. It is smart enough to deal with if one or both are missing as well.

Fixes #874