### PR TITLE
feat(app): make deploy timeout configurable globally/per-app via DEIS_DEPLOY_TIMEOUT, default is 2 minutes

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -404,6 +404,9 @@ class App(UuidAuditedModel):
         # see if the app config has deploy batch preference, otherwise use global
         batches = release.config.values.get('DEIS_DEPLOY_BATCHES', settings.DEIS_DEPLOY_BATCHES)
 
+        # see if the app config has deploy timeout preference, otherwise use global
+        deploy_timeout = release.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
+
         # see if there is a global or app specific setting to specify Deployments usage
         deployments = bool(envs.get('DEIS_KUBERNETES_DEPLOYMENTS', settings.DEIS_KUBERNETES_DEPLOYMENTS))  # noqa
 
@@ -430,7 +433,7 @@ class App(UuidAuditedModel):
                 'routable': routable,
                 'deployments': deployments,
                 'deploy_batches': batches,
-                'deploy_timeout': 120,  # 2 minutes
+                'deploy_timeout': deploy_timeout,
             }
 
             command = self._get_command(scale_type)
@@ -469,6 +472,9 @@ class App(UuidAuditedModel):
         # see if there is a global or app specific setting to specify Deployments usage
         deployments = bool(release.config.values.get('DEIS_KUBERNETES_DEPLOYMENTS', settings.DEIS_KUBERNETES_DEPLOYMENTS))  # noqa
 
+        # see if the app config has deploy timeout preference, otherwise use global
+        deploy_timeout = release.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
+
         deployment_history = release.config.values.get('KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT', settings.KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT)  # noqa
 
         # deploy application to k8s. Also handles initial scaling
@@ -497,7 +503,7 @@ class App(UuidAuditedModel):
                 'healthcheck': release.config.healthcheck,
                 'routable': routable,
                 'deploy_batches': batches,
-                'deploy_timeout': 120,  # 2 minutes
+                'deploy_timeout': deploy_timeout,
                 'deployment_history_limit': deployment_history,
                 'deployments': deployments,
                 'release_summary': release.summary
@@ -672,6 +678,9 @@ class App(UuidAuditedModel):
         if release.build is None:
             raise DeisException('No build associated with this release to run this command')
 
+        # see if the app config has deploy timeout preference, otherwise use global
+        deploy_timeout = release.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
+
         # TODO: add support for interactive shell
         entrypoint, command = self._get_command_run(command)
 
@@ -686,6 +695,7 @@ class App(UuidAuditedModel):
             'registry': release.config.registry,
             'version': "v{}".format(release.version),
             'build_type': release.build.type,
+            'deploy_timeout': deploy_timeout
         }
 
         try:

--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -359,9 +359,12 @@ class Release(UuidAuditedModel):
             'version': version
         }
 
+        # see if the app config has deploy timeout preference, otherwise use global
+        deploy_timeout = self.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
+
         controllers = self._scheduler.get_rcs(namespace, labels=labels).json()
         for controller in controllers['items']:
-            self._scheduler.cleanup_release(namespace, controller)
+            self._scheduler.cleanup_release(namespace, controller, deploy_timeout)
 
         # remove secret that contains env vars for the release
         try:

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -265,6 +265,12 @@ DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POL
 # Can also be overwritten on per app basis if desired
 DEIS_DEPLOY_BATCHES = os.environ.get('DEIS_DEPLOY_BATCHES', None)
 
+# For old style deploys (RCs) defines how long each batch
+# (as defined by DEIS_DEPLOY_BATCHES) can take before giving up
+# For Kubernetes Deployments it is part of the global timeout
+# where it roughly goes BATCHES * TIMEOUT = global timeout
+DEIS_DEPLOY_TIMEOUT = os.environ.get('DEIS_DEPLOY_TIMEOUT', 120)
+
 # If the k8s Deployments object should be used instead of ReplicationController
 DEIS_KUBERNETES_DEPLOYMENTS = bool(os.environ.get('DEIS_KUBERNETES_DEPLOYMENTS', False))
 


### PR DESCRIPTION
This will behave slightly differently between the old deploy method (RC) and Deployments

RC workflow: `DEIS_DEPLOY_TIMEOUT` refers to the base timeout *per* each `DEIS_DEPLOY_BATCHES`

Deployment workflow: `DEIS_DEPLOY_TIMEOUT` is the base timeout which then gets multipled with `DEIS_DEPLOY_BATCHES` to get an overall timeout

closes #817

[docs](https://github.com/deis/workflow/pull/374)
