### PR TITLE
chore(requirements): update Django to 1.9.8

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 backoff==1.2.1
-Django==1.9.7
+Django==1.9.8
 django-cors-headers==1.1.0
 django-guardian==1.4.4
 djangorestframework==3.4.0


### PR DESCRIPTION
See docs.djangoproject.com/en/1.9/releases/1.9.8/

These changes don't appear to affect Deis Workflow at first glance, so I don't think this is a high priority to merge. It can go in v2.3.0 IMHO.