### PR TITLE
fix(app): round the log message wait time using bankers rounding

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -638,7 +638,8 @@ class App(UuidAuditedModel):
 
         # Endpoint did not report healthy in time
         if ('response' in locals() and response.status_code == 404) or failed:
-            delta = time.time() - start
+            # bankers rounding
+            delta = round(time.time() - start)
             self.log(
                 'Router was not ready to serve traffic to process type {} in time, waited {} seconds'.format(app_type, delta),  # noqa
                 level=logging.WARNING


### PR DESCRIPTION
Instead of 10.026906251907349 it would show 10 or 11 as there is no need to show that precision level