### PR TITLE
fix(scheduler): lower case CPU limits and upper case first char in Memory limits for Kubernetes

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -619,11 +619,13 @@ class KubeHTTPClient(object):
             if mem[-2:-1].isalpha() and mem[-1].isalpha():
                 mem = mem[:-1]
 
-            mem = mem + "i"
+            # memory needs to be upper cased (only first char)
+            mem = mem.upper() + "i"
             data["resources"]["limits"]["memory"] = mem
 
         if cpu:
-            data["resources"]["limits"]["cpu"] = cpu
+            # CPU needs to be defined as lower case
+            data["resources"]["limits"]["cpu"] = cpu.lower()
 
         # add in healthchecks
         healthchecks = kwargs.get('healthcheck', None)

--- a/rootfs/scheduler/tests/test_scheduler.py
+++ b/rootfs/scheduler/tests/test_scheduler.py
@@ -53,3 +53,16 @@ class SchedulerTest(TestCase):
                                              data,
                                              healthcheck=healthcheck)
         self.assertEqual(data.get('livenessProbe'), None)
+
+    def test_set_container_limits(self):
+        """
+        Test that when _set_container has limits that is sets them properly
+        """
+        data = {}
+        self.scheduler_client._set_container(
+            'foo', 'bar', data, app_type='fake', cpu={'fake': '500M'}, memory={'fake': '1024m'}
+        )
+        # make sure CPU gets lower cased
+        self.assertEqual(data['resources']['limits']['cpu'], '500m', 'CPU should be lower cased')
+        # make sure first char of Memory is upper cased
+        self.assertEqual(data['resources']['limits']['memory'], '1024Mi', 'Memory should be upper cased')  # noqa


### PR DESCRIPTION
Fixes #915