### PR TITLE
fix(validation): success threshold can only be equal to one when setting liveness probe. Error properly

### DIFF
--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -833,7 +833,9 @@ class ConfigTest(APITransactionTestCase):
         self.assertIn('readinessProbe', resp.data['healthcheck'])
         self.assertEqual(resp.data['healthcheck'], readiness_probe['healthcheck'])
 
-        liveness_probe = {'healthcheck': {'livenessProbe': {'httpGet': {'port': 5000}}}}
+        liveness_probe = {'healthcheck': {'livenessProbe':
+                                          {'httpGet': {'port': 5000},
+                                           'successThreshold': 1}}}
         resp = self.client.post(
             '/v2/apps/{app_id}/config'.format(**locals()),
             liveness_probe)
@@ -876,6 +878,16 @@ class ConfigTest(APITransactionTestCase):
             '/v2/apps/{app_id}/config'.format(**locals()),
             {'healthcheck': json.dumps({'livenessProbe':
                                         {'httpGet': {'path': '/'}, 'initialDelaySeconds': 1}})}
+        )
+        self.assertEqual(resp.status_code, 400, response.data)
+
+        # set liveness success threshold to a non-1 value
+        # Don't set one of the mandatory value
+        resp = self.client.post(
+            '/v2/apps/{app_id}/config'.format(**locals()),
+            {'healthcheck': {'livenessProbe':
+                             {'httpGet': {'path': '/', 'port': 5000},
+                              'successThreshold': 5}}}
         )
         self.assertEqual(resp.status_code, 400, response.data)
 

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -6,6 +6,7 @@ django-guardian==1.4.4
 djangorestframework==3.4.0
 docker-py==1.9.0
 gunicorn==19.6.0
+jmespath==0.9.0
 jsonfield==1.0.3
 morph==0.1.2
 ndg-httpsclient==0.4.2


### PR DESCRIPTION
Kubernetes has this restriction, catch it before it ever makes it that far.

Introducing jmespath now to later use in other places as well

Fixes #873