### PR TITLE
fix(scale): return a 404 instead of 400 when scale uses a proc type that does not exist

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -379,7 +379,7 @@ class App(UuidAuditedModel):
                 continue  # allow docker cmd types in case we don't have the image source
 
             if container_type not in available_process_types:
-                raise DeisException(
+                raise NotFound(
                     'Container type {} does not exist in application'.format(container_type))
 
         # merge current structure and the new items together

--- a/rootfs/api/tests/deployments/test_pods.py
+++ b/rootfs/api/tests/deployments/test_pods.py
@@ -304,7 +304,7 @@ class PodTest(APITransactionTestCase):
                                                    "int() with base 10: 'not_an_int'"})
         body = {'invalid': 1}
         response = self.client.post(url, body)
-        self.assertContains(response, 'Container type invalid', status_code=400)
+        self.assertContains(response, 'Container type invalid', status_code=404)
 
     def test_container_str(self, mock_requests):
         """Test the text representation of a container."""
@@ -436,6 +436,12 @@ class PodTest(APITransactionTestCase):
         body = {'web': [1]}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400, response.data)
+
+        # scale with a non-existent proc type
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'foo': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 404, response.data)
 
         # scale up to an integer as a sanity check
         url = "/v2/apps/{app_id}/scale".format(**locals())

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -302,7 +302,7 @@ class PodTest(APITransactionTestCase):
                                                    "int() with base 10: 'not_an_int'"})
         body = {'invalid': 1}
         response = self.client.post(url, body)
-        self.assertContains(response, 'Container type invalid', status_code=400)
+        self.assertContains(response, 'Container type invalid', status_code=404)
 
     def test_container_str(self, mock_requests):
         """Test the text representation of a container."""
@@ -434,6 +434,12 @@ class PodTest(APITransactionTestCase):
         body = {'web': [1]}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400, response.data)
+
+        # scale with a non-existent proc type
+        url = "/v2/apps/{app_id}/scale".format(**locals())
+        body = {'foo': 1}
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 404, response.data)
 
         # scale up to an integer as a sanity check
         url = "/v2/apps/{app_id}/scale".format(**locals())


### PR DESCRIPTION
Fixes #830