### PR TITLE
fix(middleware): remove unused server side version check

### DIFF
--- a/rootfs/api/middleware.py
+++ b/rootfs/api/middleware.py
@@ -4,41 +4,13 @@ HTTP middleware for the Deis REST API.
 See https://docs.djangoproject.com/en/1.6/topics/http/middleware/
 """
 
-import json
-
-from django.http import HttpResponse
-from rest_framework import status
-
 from api import __version__
 
 
 class APIVersionMiddleware(object):
     """
-    Return an error if a client request is incompatible with this REST API
-    version, and include that REST API version with each response.
+    Include that REST API version with each response.
     """
-
-    def process_request(self, request):
-        """
-        Return a 405 "Not Allowed" if the request's client major version
-        doesn't match this controller's REST API major version (currently "1").
-        """
-        try:
-            client_version = request.META['HTTP_DEIS_VERSION']
-            server_version = __version__.rsplit('.', 2)[0]
-            if client_version != server_version:
-                message = {
-                    'error': 'Client and server versions do not match. ' +
-                             'Client version: {} '.format(client_version) +
-                             'Server version: {}'.format(server_version)
-                }
-                return HttpResponse(
-                    json.dumps(message),
-                    content_type='application/json',
-                    status=status.HTTP_405_METHOD_NOT_ALLOWED
-                )
-        except KeyError:
-            pass
 
     def process_response(self, request, response):
         """

--- a/rootfs/api/tests/test_api_middleware.py
+++ b/rootfs/api/tests/test_api_middleware.py
@@ -24,29 +24,9 @@ class APIMiddlewareTest(APITestCase):
 
     def test_deis_version_header_good(self):
         """
-        Test that when the version header is sent, the request is accepted.
-        """
-        response = self.client.get(
-            '/v2/apps',
-            HTTP_DEIS_VERSION=__version__.rsplit('.', 2)[0]
-        )
-        self.assertEqual(response.status_code, 200, response.data)
-        self.assertEqual(response.has_header('DEIS_API_VERSION'), True)
-        self.assertEqual(response['DEIS_API_VERSION'], __version__.rsplit('.', 1)[0])
-
-    def test_deis_version_header_bad(self):
-        """
-        Test that when an improper version header is sent, the request is declined.
-        """
-        response = self.client.get(
-            '/v2/apps',
-            HTTP_DEIS_VERSION='1234.5678'
-        )
-        self.assertEqual(response.status_code, 405, response.content)
-
-    def test_deis_version_header_not_present(self):
-        """
-        Test that when the version header is not present, the request is accepted.
+        Test that when the version header is sent.
         """
         response = self.client.get('/v2/apps')
-        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.has_header('DEIS_API_VERSION'), True)
+        self.assertEqual(response['DEIS_API_VERSION'], __version__.rsplit('.', 1)[0])


### PR DESCRIPTION
This removes code that is used to do a server side version check of the client. This hasn't been used in a very long time, as now the logic for api version mismatches is entirely client side.
