### PR TITLE
chore(requirements): move from django-cors-headers to django-cors-middleware

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,7 +1,7 @@
 # Deis controller requirements
 backoff==1.2.1
 Django==1.9.8
-django-cors-headers==1.1.0
+django-cors-middleware==1.2.0
 django-guardian==1.4.4
 djangorestframework==3.4.1
 docker-py==1.9.0


### PR DESCRIPTION
django-cors-headers is inactive and django-cors-middleware is a fork of the former