### PR TITLE
fix(run): return a 400 if command is empty

### DIFF
--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -250,8 +250,13 @@ class AppTest(DeisTestCase):
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201, response.data)
 
-        # run command
+        # cannot run command without body
         url = '/v2/apps/{}/run'.format(app_id)
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'command is a required field'})
+
+        # run command
         body = {'command': 'ls -al'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 200, response.data)

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -227,6 +227,8 @@ class AppViewSet(BaseDeisViewSet):
 
     def run(self, request, **kwargs):
         app = self.get_object()
+        if not request.data.get('command'):
+            raise DeisException("command is a required field")
         rc, output = app.run(self.request.user, request.data['command'])
         return Response({'exit_code': rc, 'output': str(output)})
 


### PR DESCRIPTION
Check if command exists before trying to access it.

