### PR TITLE
fix(middleware): move to 1.10 style middleware

### DIFF
--- a/rootfs/api/middleware.py
+++ b/rootfs/api/middleware.py
@@ -1,7 +1,7 @@
 """
 HTTP middleware for the Deis REST API.
 
-See https://docs.djangoproject.com/en/1.6/topics/http/middleware/
+See https://docs.djangoproject.com/en/1.10/topics/http/middleware/
 """
 
 from api import __version__
@@ -11,12 +11,15 @@ class APIVersionMiddleware(object):
     """
     Include that REST API version with each response.
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
 
-    def process_response(self, request, response):
+    def __call__(self, request):
         """
         Include the controller's REST API major and minor version in
         a response header.
         """
+        response = self.get_response(request)
         # clients shouldn't care about the patch release
         version = __version__.rsplit('.', 1)[0]
         response['DEIS_API_VERSION'] = version

--- a/rootfs/api/models/certificate.py
+++ b/rootfs/api/models/certificate.py
@@ -4,6 +4,7 @@ from pyasn1.type import univ, constraint
 from ndg.httpsclient.ssl_peer_verification import SUBJ_ALT_NAME_SUPPORT
 from ndg.httpsclient.subj_alt_name import SubjectAltName as BaseSubjectAltName
 from datetime import datetime
+from pytz import utc
 
 from django.shortcuts import get_object_or_404
 from django.db import models
@@ -122,7 +123,7 @@ class Certificate(AuditedModel):
             # Convert bytes to string
             timestamp = certificate.get_notAfter().decode(encoding='UTF-8')
             # convert openssl's expiry date format to Django's DateTimeField format
-            self.expires = datetime.strptime(timestamp, '%Y%m%d%H%M%SZ')
+            self.expires = datetime.strptime(timestamp, '%Y%m%d%H%M%SZ').replace(tzinfo=utc)
 
         # Grab the start date of the certificate
         if not self.starts:
@@ -130,7 +131,7 @@ class Certificate(AuditedModel):
             # Convert bytes to string
             timestamp = certificate.get_notBefore().decode(encoding='UTF-8')
             # convert openssl's starts date format to Django's DateTimeField format
-            self.starts = datetime.strptime(timestamp, '%Y%m%d%H%M%SZ')
+            self.starts = datetime.strptime(timestamp, '%Y%m%d%H%M%SZ').replace(tzinfo=utc)
 
         # process issuers - separate each key/value with a slash
         issuer = certificate.get_issuer().get_components()

--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -437,14 +437,10 @@ class CertificateSerializer(serializers.ModelSerializer):
     """Serialize a :class:`~api.models.Cert` model."""
 
     owner = serializers.ReadOnlyField(source='owner.username')
+    domains = serializers.ReadOnlyField()
     san = serializers.ListField(
         child=serializers.CharField(allow_blank=True, allow_null=True, required=False),
         required=False
-    )
-
-    domains = serializers.ListField(
-        child=serializers.CharField(allow_blank=True, allow_null=True, required=False),
-        required=False, default=[]
     )
 
     class Meta:

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -71,7 +71,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -81,7 +81,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'api.middleware.APIVersionMiddleware',
-)
+]
 
 ROOT_URLCONF = 'deis.urls'
 

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -132,7 +132,7 @@ class TokenManagementViewSet(GenericViewSet,
 
         if 'all' in request.data:
             for user in User.objects.all():
-                if not user.is_anonymous():
+                if not user.is_anonymous:
                     token = Token.objects.get(user=user)
                     token.delete()
                     Token.objects.create(user=user)

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,7 +1,7 @@
 # Deis controller requirements
 backoff==1.3.1
-Django==1.9.8
-django-cors-middleware==1.2.0
+Django==1.10.0
+django-cors-middleware==1.3.1
 django-guardian==1.4.5
 djangorestframework==3.4.4
 docker-py==1.9.0


### PR DESCRIPTION
Waiting for https://github.com/zestedesavoir/django-cors-middleware/pull/25 to land as we are blocked on that for now