### PR TITLE
fix(scheduler): make app un-routable

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -267,6 +267,9 @@ class KubeHTTPClient(object):
             # Update service information
             if routable:
                 service['metadata']['labels']['router.deis.io/routable'] = 'true'
+            else:
+                # delete the annotation
+                service['metadata']['labels'].pop('router.deis.io/routable', None)
 
             # Set app type if there is not one available
             if 'type' not in service['spec']['selector']:


### PR DESCRIPTION
If an app is not routable, then the scheduler should remove the "routable" annotation from the application's service.

This is blocked by a bug in the router: https://github.com/deis/router/issues/233

closes #973