### PR TITLE
fix(scheduler): when user asks for limits beyond their allowance then error out faster

### DIFF
--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -8,6 +8,7 @@ import requests_mock
 import string
 import time
 from urllib.parse import urlparse, parse_qs
+import uuid
 from zlib import adler32
 
 from . import KubeHTTPClient, KubeHTTPException
@@ -253,6 +254,7 @@ def create_pods(url, labels, base, new_pods):
         # creation time
         timestamp = str(datetime.utcnow().strftime(settings.DEIS_DATETIME_FORMAT))
         data['metadata']['creationTimestamp'] = timestamp
+        data['metadata']['uid'] = str(uuid.uuid4())
 
         # generate the pod name and combine with RC name
         if 'generateName' in data['metadata']:
@@ -573,6 +575,7 @@ def post(request, context):
     timestamp = str(datetime.utcnow().strftime(settings.DEIS_DATETIME_FORMAT))
     data['metadata']['creationTimestamp'] = timestamp
     data['metadata']['resourceVersion'] = 1
+    data['metadata']['uid'] = str(uuid.uuid4())
 
     # don't bother adding it to those two resources since they live outside namespace
     if resource_type not in ['nodes', 'namespaces']:


### PR DESCRIPTION
This detect errors from the pods event stream by turning the image error handling code into something slightly more generic so we can expand it over time if need be

```
Events:
  FirstSeenLastSeenCountFromSubobjectPathTypeReasonMessage
  ------------------------------------------------------------
  4m1m2{default-scheduler }WarningFailedSchedulingpod (gaslit-joyrider-cmd-2657344266-tv41n) failed to fit in any node
fit failure on node (ip-172-20-0-109.us-west-2.compute.internal): Node didn't have enough resource: CPU, requested: 2000000, used: 520, capacity: 2000
```

I made the "failed deploy, going back to old release" contain more contextual information. This can be good but may also get to be busy... Could change it so we log the additional information but do not return it via the API

# Testing Instructions

1. Create a Deis Cluster
2. Register an app
3. `deis pull deis/example-go`
4. `deis limits:set -c cmd=2000` (this should fail)

Look at the message that comes back - For now it will not look good since the CLI or SDK (or go?) are not dealing with newlines