### PR TITLE
fix(scheduler): allow Deployment "in progress" to be bypassed in case of errors or timeout

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -372,15 +372,6 @@ class Release(UuidAuditedModel):
         except KubeHTTPException:
             pass
 
-    def deployment_in_progress(self, namespace, name):
-        try:
-            ready, _ = self._scheduler.are_deployment_replicas_ready(namespace, name)
-            return not ready
-        except KubeHTTPException as e:
-            # Deployment doesn't exist
-            if e.response.status_code == 404:
-                return False
-
     def save(self, *args, **kwargs):  # noqa
         if not self.summary:
             self.summary = ''


### PR DESCRIPTION
It is possible to get a Deployment into a state where it can not bring up pods. The API will think that means that the Deployment is still "in progress". The scenario around this mostly happens when the client connection (CLI) is lost and the API loses context.

This change brings in the ability to get past the "in progress" stop sign when the Deployment is found to have errors (image not found, limits are bad, etc) or it has been in that state for more than the overall deploy timout limit is

Fixes #706
Refs #785
Replaces #792

### Testing Instructions

* Create a Deis Cluster
* `deis create --no-remote progress
* `deis pull deis/example-go -a progress`
* `deis limits:set -c cmd=9999999 -a progress` (this should fail)
* `deis config:set foo=bar -a progress` (this should succeed)
* `deis limits -a progress` (this should show Unlimited and not `999999999`
* `k get po --namespace progress -o yaml | grep version` should show `version: v3`
* `deis releases -a progress` should have on mention of limits