### PR TITLE
fix(registry): tell a user they need PORT when using off-cluster native iaas registry

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -152,8 +152,10 @@ class Release(UuidAuditedModel):
             # application has registry auth - $PORT is required
             if (creds is not None) or (settings.REGISTRY_LOCATION != 'on-cluster'):
                 if envs.get('PORT', None) is None:
-                    self.app.log('Private registry detected but no $PORT defined. Defaulting to $PORT 5000', logging.WARNING)  # noqa
-                    return 5000
+                    raise DeisException(
+                        'PORT needs to be set in the config '
+                        'when using a private registry'
+                    )
 
                 # User provided PORT
                 return int(envs.get('PORT'))


### PR DESCRIPTION
registry:set does the same kind of warning but since this is a whole platform setting then we need to warn on deploy as well

Fixes #986

Requires off-cluster native iaas cluster to test

```
deis create --no-remote
Creating Application... done, created august-sandwich
If you want to add a git remote for this app later, use `deis git:remote -a august-sandwich`

deis pull deis/example-go -a august-sandwich
Creating build... Error: Unknown Error (400): {"detail":"PORT needs to be set in the config when using a private registry"}

deis config:set PORT=80 -a august-sandwich
Creating config... done

=== august-sandwich Config
PORT      80

deis pull deis/example-go -a august-sandwich
```