### PR TITLE
chore(rootfs/Dockerfile): update to latest base image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.3.0
+FROM quay.io/deis/base:0.3.1
 
 RUN adduser --system \
 	--shell /bin/bash \


### PR DESCRIPTION
Has pre-created man page directories to work around an issue with `apt-get install postgresql-client,` for one example.

Refs deis/docker-base#6. Ping @jgmize.