### PR TITLE
ref(api): change image pull policy to "IfNotPresent"

### DIFF
--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -254,8 +254,8 @@ BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', random_secret)
 
 # k8s image policies
 SLUGRUNNER_IMAGE = os.environ.get('SLUGRUNNER_IMAGE_NAME', 'quay.io/deisci/slugrunner:canary')  # noqa
-SLUG_BUILDER_IMAGE_PULL_POLICY = os.environ.get('SLUG_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
-DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POLICY', "Always")  # noqa
+SLUG_BUILDER_IMAGE_PULL_POLICY = os.environ.get('SLUG_BUILDER_IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
+DOCKER_BUILDER_IMAGE_PULL_POLICY = os.environ.get('DOCKER_BUILDER_IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
 
 # Define a global default on how many pods to bring up and then
 # take down sequentially during a deploy


### PR DESCRIPTION
When networking issues are present with quay.io or Dockerhub, deploys with `deis pull` images will
always fail because the image pull policy is set to "Always". Even if every node in the cluster has
the image, the deploy will still fail because dockerhub or quay.io is down.