### PR TITLE
ref(Makefile): use make test-unit-quick by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ setup-venv:
 	@if [ ! -d venv ]; then pyvenv venv && source venv/bin/activate; fi
 	pip install --disable-pip-version-check -q -r rootfs/requirements.txt -r rootfs/dev_requirements.txt
 
-test: test-style test-check test-unit test-functional
+test: test-style test-check test-unit-quick test-functional
 
 test-check:
 	cd rootfs && python manage.py check


### PR DESCRIPTION
This target runs all the unit tests but in parallel, speeding up test time on Travis.