### PR TITLE
ref(scheduler): add HTTP functions in KubeHTTPClient

### DIFF
--- a/rootfs/scheduler/resources/__resource.py
+++ b/rootfs/scheduler/resources/__resource.py
@@ -1,4 +1,3 @@
-from urllib.parse import urljoin
 from .. import KubeHTTPClient
 
 
@@ -26,5 +25,4 @@ class Resource(KubeHTTPClient, metaclass=ResourceRegistry):
 
     def api(self, tmpl, *args):
         """Return a fully-qualified Kubernetes API URL from a string template with args."""
-        url = "/{}/{}".format(self.api_prefix, self.api_version) + tmpl.format(*args)
-        return urljoin(self.url, url)
+        return "/{}/{}".format(self.api_prefix, self.api_version) + tmpl.format(*args)

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -23,7 +23,7 @@ class Deployment(Resource):
             message = 'get Deployments in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -111,7 +111,7 @@ class Deployment(Resource):
                                  entrypoint, command, **kwargs)
 
         url = self.api("/namespaces/{}/deployments", namespace)
-        response = self.session.post(url, json=manifest)
+        response = self.http_post(url, json=manifest)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,
@@ -129,7 +129,7 @@ class Deployment(Resource):
                                  entrypoint, command, **kwargs)
 
         url = self.api("/namespaces/{}/deployments/{}", namespace, name)
-        response = self.session.put(url, json=manifest)
+        response = self.http_put(url, json=manifest)
         if self.unhealthy(response.status_code):
             self.log(namespace, 'template used: {}'.format(json.dumps(manifest, indent=4)), 'DEBUG')  # noqa
             raise KubeHTTPException(response, 'update Deployment "{}"', name)
@@ -141,7 +141,7 @@ class Deployment(Resource):
 
     def delete(self, namespace, name):
         url = self.api("/namespaces/{}/deployments/{}", namespace, name)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/horizontalpodautoscaler.py
+++ b/rootfs/scheduler/resources/horizontalpodautoscaler.py
@@ -31,7 +31,7 @@ class HorizontalPodAutoscaler(Resource):
             message = 'get HorizontalPodAutoscalers in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -97,7 +97,7 @@ class HorizontalPodAutoscaler(Resource):
         manifest = self.manifest(namespace, name, app_type, target, **kwargs)
 
         url = self.api("/namespaces/{}/horizontalpodautoscalers", namespace)
-        response = self.session.post(url, json=manifest)
+        response = self.http_post(url, json=manifest)
         if self.unhealthy(response.status_code):
             self.log(namespace, 'template used: {}'.format(json.dumps(manifest, indent=4)), 'DEBUG')  # noqa
             raise KubeHTTPException(
@@ -115,7 +115,7 @@ class HorizontalPodAutoscaler(Resource):
         manifest = self.manifest(namespace, name, app_type, target, **kwargs)
 
         url = self.api("/namespaces/{}/horizontalpodautoscalers/{}", namespace, name)
-        response = self.session.put(url, json=manifest)
+        response = self.http_put(url, json=manifest)
         if self.unhealthy(response.status_code):
             self.log(namespace, 'template used: {}'.format(json.dumps(manifest, indent=4)), 'DEBUG')  # noqa
             raise KubeHTTPException(response, 'update HorizontalPodAutoscaler "{}"', name)
@@ -128,7 +128,7 @@ class HorizontalPodAutoscaler(Resource):
 
     def delete(self, namespace, name):
         url = self.api("/namespaces/{}/horizontalpodautoscalers/{}", namespace, name)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/namespace.py
+++ b/rootfs/scheduler/resources/namespace.py
@@ -19,7 +19,7 @@ class Namespace(Resource):
             message = 'get Namespaces'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -39,7 +39,7 @@ class Namespace(Resource):
             }
         }
 
-        response = self.session.post(url, json=data)
+        response = self.http_post(url, json=data)
         if not response.status_code == 201:
             raise KubeHTTPException(response, "create Namespace {}".format(namespace))
 
@@ -47,7 +47,7 @@ class Namespace(Resource):
 
     def delete(self, namespace):
         url = self.api("/namespaces/{}", namespace)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(response, 'delete Namespace "{}"', namespace)
 
@@ -55,7 +55,7 @@ class Namespace(Resource):
 
     def events(self, namespace, **kwargs):
         url = self.api("/namespaces/{}/events", namespace)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(response, "get Events in Namespace {}", namespace)
 

--- a/rootfs/scheduler/resources/node.py
+++ b/rootfs/scheduler/resources/node.py
@@ -19,7 +19,7 @@ class Node(Resource):
             message = 'get Nodes'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -26,7 +26,7 @@ class Pod(Resource):
             message = 'get Pods in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -324,7 +324,7 @@ class Pod(Resource):
 
         # delete pod
         url = self.api("/namespaces/{}/pods/{}", namespace, name)
-        resp = self.session.delete(url)
+        resp = self.http_delete(url)
         if self.unhealthy(resp.status_code):
             raise KubeHTTPException(resp, 'delete Pod "{}" in Namespace "{}"', name, namespace)
 
@@ -344,7 +344,7 @@ class Pod(Resource):
 
     def logs(self, namespace, name):
         url = self.api("/namespaces/{}/pods/{}/log", namespace, name)
-        response = self.session.get(url)
+        response = self.http_get(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/replicaset.py
+++ b/rootfs/scheduler/resources/replicaset.py
@@ -21,7 +21,7 @@ class ReplicaSet(Resource):
             message = 'get ReplicaSets in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)

--- a/rootfs/scheduler/resources/replicationcontroller.py
+++ b/rootfs/scheduler/resources/replicationcontroller.py
@@ -21,7 +21,7 @@ class ReplicationController(Resource):
             message = 'get ReplicationControllers in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -54,7 +54,7 @@ class ReplicationController(Resource):
         manifest['spec']['template'] = self.pod.manifest(namespace, name, image, **kwargs)
 
         url = self.api("/namespaces/{}/replicationcontrollers", namespace)
-        resp = self.session.post(url, json=manifest)
+        resp = self.http_post(url, json=manifest)
         if self.unhealthy(resp.status_code):
             raise KubeHTTPException(
                 resp,
@@ -68,7 +68,7 @@ class ReplicationController(Resource):
 
     def update(self, namespace, name, data):
         url = self.api("/namespaces/{}/replicationcontrollers/{}", namespace, name)
-        response = self.session.put(url, json=data)
+        response = self.http_put(url, json=data)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(response, 'scale ReplicationController "{}"', name)
 
@@ -76,7 +76,7 @@ class ReplicationController(Resource):
 
     def delete(self, namespace, name):
         url = self.api("/namespaces/{}/replicationcontrollers/{}", namespace, name)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/scale.py
+++ b/rootfs/scheduler/resources/scale.py
@@ -26,7 +26,7 @@ class Scale(Resource):
 
         manifest = self.manifest(namespace, name, replicas)
         url = self.api("/namespaces/{}/{}/{}/scale", namespace, resource_type, name)
-        response = self.session.put(url, json=manifest)
+        response = self.http_put(url, json=manifest)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/secret.py
+++ b/rootfs/scheduler/resources/secret.py
@@ -19,7 +19,7 @@ class Secret(Resource):
             message = 'get Secrets in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -81,7 +81,7 @@ class Secret(Resource):
     def create(self, namespace, name, data, secret_type='Opaque', labels={}):
         manifest = self.manifest(namespace, name, data, secret_type, labels)
         url = self.api("/namespaces/{}/secrets", namespace)
-        response = self.session.post(url, json=manifest)
+        response = self.http_post(url, json=manifest)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,
@@ -93,7 +93,7 @@ class Secret(Resource):
     def update(self, namespace, name, data, secret_type='Opaque', labels={}):
         manifest = self.manifest(namespace, name, data, secret_type, labels)
         url = self.api("/namespaces/{}/secrets/{}", namespace, name)
-        response = self.session.put(url, json=manifest)
+        response = self.http_put(url, json=manifest)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,
@@ -105,7 +105,7 @@ class Secret(Resource):
 
     def delete(self, namespace, name):
         url = self.api("/namespaces/{}/secrets/{}", namespace, name)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/resources/service.py
+++ b/rootfs/scheduler/resources/service.py
@@ -20,7 +20,7 @@ class Service(Resource):
             message = 'get Services in Namespace "{}"'
 
         url = self.api(url, *args)
-        response = self.session.get(url, params=self.query_params(**kwargs))
+        response = self.http_get(url, params=self.query_params(**kwargs))
         if self.unhealthy(response.status_code):
             args.reverse()  # error msg is in reverse order
             raise KubeHTTPException(response, message, *args)
@@ -56,7 +56,7 @@ class Service(Resource):
 
         data = dict_merge(manifest, kwargs.get('data', {}))
         url = self.api("/namespaces/{}/services", namespace)
-        response = self.session.post(url, json=data)
+        response = self.http_post(url, json=data)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,
@@ -67,7 +67,7 @@ class Service(Resource):
 
     def update(self, namespace, name, data):
         url = self.api("/namespaces/{}/services/{}", namespace, name)
-        response = self.session.put(url, json=data)
+        response = self.http_put(url, json=data)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,
@@ -78,7 +78,7 @@ class Service(Resource):
 
     def delete(self, namespace, name):
         url = self.api("/namespaces/{}/services/{}", namespace, name)
-        response = self.session.delete(url)
+        response = self.http_delete(url)
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(
                 response,

--- a/rootfs/scheduler/tests/test_kubehttpclient.py
+++ b/rootfs/scheduler/tests/test_kubehttpclient.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for the Deis scheduler module.
+
+Run the tests with "./manage.py test scheduler"
+"""
+import json
+import requests
+import requests_mock
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+import scheduler
+from scheduler import exceptions
+
+
+def mock_session():
+    return requests.Session()
+
+
+def connection_refused_matcher(request):
+    raise requests.ConnectionError("connection refused")
+
+
+@mock.patch('scheduler.get_session', mock_session)
+class KubeHTTPClientTest(TestCase):
+    """Tests kubernetes HTTP client calls"""
+
+    def setUp(self):
+        self.adapter = requests_mock.Adapter()
+        self.path = '/foo'
+        self.url = settings.SCHEDULER_URL + self.path
+        # use the real scheduler client.
+        self.scheduler = scheduler.KubeHTTPClient(settings.SCHEDULER_URL)
+        self.scheduler.session.mount(self.url, self.adapter)
+
+    def test_head(self):
+        """
+        Test that calling .http_head() uses the client session to make a HEAD request.
+        """
+        self.adapter.register_uri('HEAD', self.url)
+        response = self.scheduler.http_head(self.path)
+        assert response is not None
+        self.assertTrue(self.adapter.called)
+        self.assertEqual(self.adapter.call_count, 1)
+        # ensure that connection errors get raised as a KubeException
+        self.adapter.add_matcher(connection_refused_matcher)
+        with self.assertRaises(exceptions.KubeException):
+            self.scheduler.http_head(self.path)
+
+    def test_get(self):
+        """
+        Test that calling .http_get() uses the client session to make a GET request.
+        """
+        self.adapter.register_uri('GET', self.url)
+        response = self.scheduler.http_get(self.path)
+        assert response is not None
+        self.assertTrue(self.adapter.called)
+        self.assertEqual(self.adapter.call_count, 1)
+        # ensure that connection errors get raised as a KubeException
+        self.adapter.add_matcher(connection_refused_matcher)
+        with self.assertRaises(exceptions.KubeException):
+            self.scheduler.http_get(self.path)
+
+    def test_post(self):
+        """
+        Test that calling .http_post() uses the client session to make a POST request.
+        """
+        self.adapter.register_uri('POST', self.url)
+        response = self.scheduler.http_post(self.path, data=json.dumps({'hello': 'world'}))
+        assert response is not None
+        self.assertTrue(self.adapter.called)
+        self.assertEqual(self.adapter.call_count, 1)
+        # ensure that connection errors get raised as a KubeException
+        self.adapter.add_matcher(connection_refused_matcher)
+        with self.assertRaises(exceptions.KubeException):
+            self.scheduler.http_post(self.path)
+
+    def test_put(self):
+        """
+        Test that calling .http_put() uses the client session to make a PUT request.
+        """
+        self.adapter.register_uri('PUT', self.url)
+        response = self.scheduler.http_put(self.path, data=json.dumps({'hello': 'world'}))
+        assert response is not None
+        self.assertTrue(self.adapter.called)
+        self.assertEqual(self.adapter.call_count, 1)
+        # ensure that connection errors get raised as a KubeException
+        self.adapter.add_matcher(connection_refused_matcher)
+        with self.assertRaises(exceptions.KubeException):
+            self.scheduler.http_put(self.path)
+
+    def test_delete(self):
+        """
+        Test that calling .http_delete() uses the client session to make a DELETE request.
+        """
+        self.adapter.register_uri('DELETE', self.url)
+        response = self.scheduler.http_delete(self.path)
+        assert response is not None
+        self.assertTrue(self.adapter.called)
+        self.assertEqual(self.adapter.call_count, 1)
+        # ensure that connection errors get raised as a KubeException
+        self.adapter.add_matcher(connection_refused_matcher)
+        with self.assertRaises(exceptions.KubeException):
+            self.scheduler.http_delete(self.path)


### PR DESCRIPTION
These functions properly handle connection errors and clean up some of the child/parent class
relations when making a request.

closes #1008 