### PR TITLE
chore(requirements): update PyOpenSSL to 16.1.0

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -11,7 +11,7 @@ jsonfield==1.0.3
 morph==0.1.2
 ndg-httpsclient==0.4.2
 psycopg2==2.6.2
-pyOpenSSL==16.0.0
+pyOpenSSL==16.1.0
 pytz==2016.6.1
 requests==2.11.1
 requests-toolbelt==0.7.0


### PR DESCRIPTION
https://github.com/pyca/pyopenssl/blob/master/CHANGELOG.rst#1610-2016-08-26