### PR TITLE
feat(scheduler): add the ability to set KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS per application

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -405,6 +405,9 @@ class App(UuidAuditedModel):
         # see if the app config has deploy timeout preference, otherwise use global
         deploy_timeout = release.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
 
+        # get application level pod termination grace period
+        pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
+
         tasks = []
         for scale_type, replicas in scale_types.items():
             # only web / cmd are routable
@@ -433,6 +436,7 @@ class App(UuidAuditedModel):
                 'routable': routable,
                 'deploy_batches': batches,
                 'deploy_timeout': deploy_timeout,
+                'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
             }
 
             # gather all proc types to be deployed
@@ -486,6 +490,9 @@ class App(UuidAuditedModel):
 
         deployment_history = release.config.values.get('KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT', settings.KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT)  # noqa
 
+        # get application level pod termination grace period
+        pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
+
         # deploy application to k8s. Also handles initial scaling
         deploys = {}
         image = release.image
@@ -512,7 +519,6 @@ class App(UuidAuditedModel):
                 'tags': tags,
                 'envs': envs,
                 'registry': release.config.registry,
-                # only used if there is no previous RC
                 'replicas': replicas,
                 'version': version,
                 'app_type': scale_type,
@@ -522,7 +528,8 @@ class App(UuidAuditedModel):
                 'deploy_batches': batches,
                 'deploy_timeout': deploy_timeout,
                 'deployment_history_limit': deployment_history,
-                'release_summary': release.summary
+                'release_summary': release.summary,
+                'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
             }
 
         # Sort deploys so routable comes first
@@ -729,6 +736,9 @@ class App(UuidAuditedModel):
         # see if the app config has deploy timeout preference, otherwise use global
         deploy_timeout = release.config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)  # noqa
 
+        # get application level pod termination grace period
+        pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
+
         name = self._get_job_id(scale_type) + '-' + pod_name()
         self.log("{} on {} runs '{}'".format(user.username, name, command))
 
@@ -743,7 +753,8 @@ class App(UuidAuditedModel):
             'registry': release.config.registry,
             'version': version,
             'build_type': release.build.type,
-            'deploy_timeout': deploy_timeout
+            'deploy_timeout': deploy_timeout,
+            'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
         }
 
         try:

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -21,6 +21,7 @@ class DeploymentsTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         deployment = self.scheduler.deployment.create(namespace, name, 'quay.io/fake/image',
@@ -38,6 +39,7 @@ class DeploymentsTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         deployment = self.scheduler.deployment.update(namespace, name, 'quay.io/fake/image',
@@ -56,6 +58,7 @@ class DeploymentsTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         self.scheduler.scale(namespace, name, 'quay.io/fake/image', 'sh', 'start', **kwargs)

--- a/rootfs/scheduler/tests/test_horizontalpodautoscaler.py
+++ b/rootfs/scheduler/tests/test_horizontalpodautoscaler.py
@@ -23,6 +23,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 1),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         # create a Deployment to test HPA with
@@ -68,6 +69,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         deployment = self.scheduler.deployment.update(namespace, name, 'quay.io/fake/image',

--- a/rootfs/scheduler/tests/test_replicationcontrollers.py
+++ b/rootfs/scheduler/tests/test_replicationcontrollers.py
@@ -21,6 +21,7 @@ class ReplicationControllersTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
+            'pod_termination_grace_period_seconds': 2,
         }
 
         rc = self.scheduler.rc.create(namespace, name, 'quay.io/fake/image',
@@ -39,7 +40,8 @@ class ReplicationControllersTest(TestCase):
             'app_type': kwargs.get('app_type', 'web'),
             'version': kwargs.get('version', 'v99'),
             'replicas': kwargs.get('replicas', 4),
-            'deploy_timeout': 120
+            'deploy_timeout': 120,
+            'pod_termination_grace_period_seconds': 2,
         }
 
         self.scheduler.scale_rc(namespace, name, 'quay.io/fake/image', 'sh', 'start', **kwargs)


### PR DESCRIPTION
This makes a few internal methods now fetch the timeout from the pod instead of depending on outside info, previously it was fetching the info from global django.settings object.

Makes `pod_termination_grace_period_seconds` a required param for a few scheduler methods, like we already have with `app_type` etc etc

Close #807