### PR TITLE
fix(app): rollback all process types to previous version when one (or  more) process type fails a deploy

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -181,15 +181,8 @@ class KubeHTTPClient(object):
                     namespace, name, image, entrypoint, command, **kwargs
                 )
             except KubeException as e:
-                # rollback to the previous Deployment
-                kwargs['rollback'] = True
-                self.deployment.update(
-                    namespace, name, image, entrypoint, command, **kwargs
-                )
-
                 raise KubeException(
                     'There was a problem while deploying {} of {}-{}. '
-                    'Going back to the previous release. '
                     "Additional information:\n{}".format(version, namespace, app_type, str(e))
                 ) from e
 


### PR DESCRIPTION
Previously only the failed process type would roll itself back, resulting in a scenario where worker may be on v6 and web on v5

This moves away from using the built in rollback functionality in Deployments and rather deploys the previous release again to get the same effect.
Rollback in Deployments was taking it to the last good known deployment, in this case that'd be the latest for some types... knowing the revision of the last deploy would be hard as well.

The way it works when deploying the old release is an identical replicaset (and thus identical template pod hash is generated) so things will very much so look like a native rollback.
If the Controller has done any changes to how it constructs the pod manifest then this could generate a totally new ReplicaSet but that is also fine as it will be booting the previous release from DB

Fixes #1013

### Test Plan

1. `deis create --no-remote test-rollback`
2. `deis pull deis/example-go -a test-rollback`
3. `deis config:set foo=bar -a test-rollback`
4. `deis pull deis/example-foo -a test-rollback`

There should be an error message along the lines of `(app::deploy): There was a problem deploying v6. Rolling back process types to release v5.\nThere was a problem while deploying v6 of test-rollback-cmd. Additional information:\nError: image deis/example-foo:latest not found`

Running `deis logs -a test-rollback` should show some of that, including `There was a problem deploying v6. Rolling back process types to release v5` twice. That's okay and is due to https://github.com/deis/logger/issues/109

The first one is when the internal rollback starts and the second one is when that message is combined with the information returned back to the user