### PR TITLE
feat(scheduler): use /scale endpoints for RC and Deployments to only update replicas during scale events

### DIFF
--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -162,10 +162,14 @@ class Deployment(Resource):
             self.log(namespace, "Not scaling Deployment {} to {} replicas. Already at desired replicas".format(name, desired))  # noqa
             return
         elif desired != current:
+            self.log(namespace, "scaling Deployment {} from {} to {} replicas".format(name, current, desired))  # noqa
+            self.scales.update(namespace, name, desired, deployment)
+
+            # wait until scaling is done
+            self.wait_until_updated(namespace, name)
             # set the previous replicas count so the wait logic can deal with terminating pods
             kwargs['previous_replicas'] = current
-            self.log(namespace, "scaling Deployment {} from {} to {} replicas".format(name, current, desired))  # noqa
-            self.update(namespace, name, image, entrypoint, command, **kwargs)
+            self.wait_until_ready(namespace, name, **kwargs)
 
     def in_progress(self, namespace, name, deploy_timeout, batches, replicas, tags):
         """

--- a/rootfs/scheduler/resources/replicationcontroller.py
+++ b/rootfs/scheduler/resources/replicationcontroller.py
@@ -93,12 +93,8 @@ class ReplicationController(Resource):
             self.log(namespace, "Not scaling RC {} to {} replicas. Already at desired replicas".format(name, desired))  # noqa
             return
         elif desired != rc['spec']['replicas']:  # RC needs new replica count
-            # Set the new desired replica count
-            rc['spec']['replicas'] = desired
-
             self.log(namespace, "scaling RC {} from {} to {} replicas".format(name, current, desired))  # noqa
-
-            self.update(namespace, name, rc)
+            self.scales.update(namespace, name, desired, rc)
             self.wait_until_updated(namespace, name)
 
         # Double check enough pods are in the required state to service the application

--- a/rootfs/scheduler/resources/scale.py
+++ b/rootfs/scheduler/resources/scale.py
@@ -1,0 +1,37 @@
+from scheduler.resources import Resource
+from scheduler.exceptions import KubeHTTPException
+
+
+class Scale(Resource):
+    def manifest(self, namespace, name, replicas):
+        manifest = {
+            'kind': 'Scale',
+            'apiVersion': self.api_version,
+            'metadata': {
+                'namespace': namespace,
+                'name': name,
+            },
+            'spec': {
+                'replicas': replicas,
+            }
+        }
+
+        return manifest
+
+    def update(self, namespace, name, replicas, target):
+        # use API version and prefix from target use pick the right endpoint
+        resource_type = target['kind'].lower() + 's'  # make plural for url
+        self.api_version = getattr(self, resource_type).api_version
+        self.api_prefix = getattr(self, resource_type).api_prefix
+
+        manifest = self.manifest(namespace, name, replicas)
+        url = self.api("/namespaces/{}/{}/{}/scale", namespace, resource_type, name)
+        response = self.session.put(url, json=manifest)
+        if self.unhealthy(response.status_code):
+            raise KubeHTTPException(
+                response,
+                'scale {} "{}" in Namespace "{}"', target['kind'], name, namespace
+            )
+            self.log(namespace, 'template used: {}'.format(json.dumps(manifest, indent=4)), 'DEBUG')  # noqa
+
+        return response


### PR DESCRIPTION
Prior to this a full resource update was being done during a scale event, this could lead to potential pod template updates that were not desired

Fixes #1012