### PR TITLE
fix(app): create image pull secrets outside of the async deploy loop

### DIFF
--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -3,6 +3,8 @@ Unit tests for the Deis api app.
 
 Run the tests with "./manage.py test api"
 """
+import base64
+import json
 import logging
 from unittest import mock
 import random
@@ -11,6 +13,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
+from django.test.utils import override_settings
 from rest_framework.authtoken.models import Token
 
 from api.models import App
@@ -507,6 +510,60 @@ class AppTest(DeisTestCase):
         svc = app._fetch_service_config(app_id)
         self.assertIn('labels', svc['metadata'])
         self.assertIn('annotations', svc['metadata'])
+
+    def test_get_private_registry_config(self, mock_requests):
+        registry = {'username': 'test', 'password': 'test'}
+        auth = bytes('{}:{}'.format("test", "test"), 'UTF-8')
+        encAuth = base64.b64encode(auth).decode(encoding='UTF-8')
+        image = 'test/test'
+
+        docker_config, name, create = App()._get_private_registry_config(image, registry)
+        dockerConfig = json.loads(docker_config)
+        expected = {"https://index.docker.io/v1/": {"auth": encAuth}}
+        self.assertEqual(dockerConfig.get('auths'), expected)
+        self.assertEqual(name, "private-registry")
+        self.assertEqual(create, True)
+
+        image = "quay.io/test/test"
+        docker_config, name, create = App()._get_private_registry_config(image, registry)
+        dockerConfig = json.loads(docker_config)
+        expected = {"quay.io": {"auth": encAuth}}
+        self.assertEqual(dockerConfig.get('auths'), expected)
+        self.assertEqual(name, "private-registry")
+        self.assertEqual(create, True)
+
+    @override_settings(REGISTRY_LOCATION="ecr")
+    def test_get_private_registry_config_ecr(self, mock_requests):
+        registry = {}
+        image = "test.com/test/test"
+        docker_config, name, create = App()._get_private_registry_config(image, registry)
+        self.assertEqual(docker_config, None)
+        self.assertEqual(name, "private-registry-ecr")
+        self.assertEqual(create, False)
+
+    @override_settings(REGISTRY_LOCATION="off-cluster")
+    def test_get_private_registry_config_off_cluster(self, mock_requests):
+        registry = {}
+        auth = bytes('{}:{}'.format("test", "test"), 'UTF-8')
+        encAuth = base64.b64encode(auth).decode(encoding='UTF-8')
+        image = "test.com/test/test"
+        docker_config, name, create = App()._get_private_registry_config(image, registry)
+        dockerConfig = json.loads(docker_config)
+        expected = {"https://index.docker.io/v1/": {
+            "auth": encAuth
+        }}
+        self.assertEqual(dockerConfig.get('auths'), expected)
+        self.assertEqual(name, "private-registry-off-cluster")
+        self.assertEqual(create, True)
+
+    @override_settings(REGISTRY_LOCATION="ecra")
+    def test_get_private_registry_config_bad_registry_location(self, mock_requests):
+        registry = {}
+        image = "test.com/test/test"
+        docker_config, name, create = App()._get_private_registry_config(image, registry)
+        self.assertEqual(docker_config, None)
+        self.assertEqual(name, None)
+        self.assertEqual(create, None)
 
 
 FAKE_LOG_DATA = """


### PR DESCRIPTION
The issue is that multiple process types can cause 409 issues when ran in the async process. It's fine to run this ahead of any deploy as this secret is not tied to the release version of an application

Moved pull image secret and registry config generation into the App model as it makes more sense given where it gets used.
Also reduces `django.settings` in the `scheduler`

Fixes #1031