### PR TITLE
fix(logs): app logs endpoint was returning binary string instead of a normal string

### DIFF
--- a/rootfs/api/__init__.py
+++ b/rootfs/api/__init__.py
@@ -2,4 +2,4 @@
 The **api** Django app presents a RESTful web API for interacting with the **deis** system.
 """
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -735,7 +735,7 @@ class App(UuidAuditedModel):
             raise ServiceUnavailable('Error accessing deis-logger')
 
         # cast content to string since it comes as bytes via the requests object
-        return str(r.content)
+        return str(r.content.decode('utf-8'))
 
     def run(self, user, command):
         def pod_name(size=5, chars=string.ascii_lowercase + string.digits):

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -89,7 +89,7 @@ class AppTest(DeisTestCase):
         self.assertContains(response, 'Application with this id already exists.', status_code=400)
 
     @mock.patch('requests.get')
-    def test_app_actions(self, mock_requests, mock_get):
+    def test_app_logs(self, mock_requests, mock_get):
         app_id = self.create_app()
 
         # test logs - 204 from deis-logger
@@ -111,7 +111,8 @@ class AppTest(DeisTestCase):
         self.assertContains(
             response,
             "Error accessing logs for {}".format(app_id),
-            status_code=500)
+            status_code=500
+        )
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
@@ -125,9 +126,8 @@ class AppTest(DeisTestCase):
         self.assertContains(
             response,
             "Error accessing logs for {}".format(app_id),
-            status_code=500)
-
-        # TODO: test run needs an initial build
+            status_code=500
+        )
 
     @mock.patch('api.models.logger')
     def test_app_release_notes_in_logs(self, mock_requests, mock_logger):
@@ -566,9 +566,9 @@ class AppTest(DeisTestCase):
         self.assertEqual(create, None)
 
 
-FAKE_LOG_DATA = """
+FAKE_LOG_DATA = bytes("""
 2013-08-15 12:41:25 [33454] [INFO] Starting gunicorn 17.5
 2013-08-15 12:41:25 [33454] [INFO] Listening at: http://0.0.0.0:5000 (33454)
 2013-08-15 12:41:25 [33454] [INFO] Using worker: sync
 2013-08-15 12:41:25 [33457] [INFO] Booting worker with pid 33457
-"""
+""", 'utf-8')


### PR DESCRIPTION
When python-requests got data from logger it was in binary string format, converting that to normal string was sufficient

Docs change https://github.com/deis/workflow/pull/485

Fixes #1033