### PR TITLE
fix(scheduler): pass down the right variable for Deployment revision history limit

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -540,7 +540,7 @@ class App(UuidAuditedModel):
                 'routable': routable,
                 'deploy_batches': batches,
                 'deploy_timeout': deploy_timeout,
-                'deployment_history_limit': deployment_history,
+                'deployment_revision_history_limit': deployment_history,
                 'release_summary': release.summary,
                 'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
                 'image_pull_secret_name': image_pull_secret_name,

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -94,8 +94,8 @@ class Deployment(Resource):
         }
 
         # Add in how many deployment revisions to keep
-        if kwargs.get('deployment_revision_history', None) is not None:
-            manifest['spec']['revisionHistoryLimit'] = int(kwargs.get('deployment_revision_history'))  # noqa
+        if kwargs.get('deployment_revision_history_limit', None) is not None:
+            manifest['spec']['revisionHistoryLimit'] = int(kwargs.get('deployment_revision_history_limit'))  # noqa
 
         # tell pod how to execute the process
         kwargs['command'] = entrypoint


### PR DESCRIPTION
Prior to this the wrong variable was being passed and as such the revision history feature did not work