### PR TITLE
fix(scheduler): show more information when there is a HTTP error in Kubernetes

### DIFF
--- a/rootfs/scheduler/exceptions.py
+++ b/rootfs/scheduler/exceptions.py
@@ -7,10 +7,14 @@ class KubeHTTPException(KubeException):
     def __init__(self, response, errmsg, *args, **kwargs):
         self.response = response
 
+        data = response.json()
+        message = data['message'] if 'message' in data else ''
+
         msg = errmsg.format(*args)
-        msg = "failed to {}: {} {}".format(
+        msg = 'failed to {}: {} {} {}'.format(
             msg,
             response.status_code,
-            response.reason
+            response.reason,
+            message
         )
         KubeException.__init__(self, msg, *args, **kwargs)


### PR DESCRIPTION
With the response below the user would get the very unhelpful `422 Invalid` - This extends that

```
{
    'code': 422,
    'reason': 'Invalid',
    'apiVersion': 'v1',
    'metadata': {},
    'kind': 'Status',
    'details': {
        'kind': 'Service',
        'causes': [
            {'field': 'spec.clusterIP', 'reason': 'FieldValueInvalid', 'message': "invalid value '', Details: range is full"}
        ],
        'name': 'test-760092409'
    },
    'message': 'Service "test-760092409" is invalid: spec.clusterIP: invalid value \'\', Details: range is full',
    'status': 'Failure'
}
```