### PR TITLE
fix(api): create TLS object on app create

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -26,6 +26,7 @@ from api.utils import generate_app_name, async_run
 from api.models.release import Release
 from api.models.config import Config
 from api.models.domain import Domain
+from api.models.tls import TLS
 from api.models.appsettings import AppSettings
 
 from scheduler import KubeHTTPException, KubeException
@@ -228,6 +229,10 @@ class App(UuidAuditedModel):
             self.appsettings_set.latest()
         except AppSettings.DoesNotExist:
             AppSettings.objects.create(owner=self.owner, app=self)
+        try:
+            self.tls_set.latest()
+        except TLS.DoesNotExist:
+            TLS.objects.create(owner=self.owner, app=self)
         # Attach the platform specific application sub domain to the k8s service
         # Only attach it on first release in case a customer has remove the app domain
         if rel.version == 1 and not Domain.objects.filter(domain=self.id).exists():

--- a/rootfs/api/tests/test_tls.py
+++ b/rootfs/api/tests/test_tls.py
@@ -61,3 +61,14 @@ class TestTLS(DeisTransactionTestCase):
             '/v2/apps/{app_id}/tls'.format(**locals()),
             data)
         self.assertEqual(response.status_code, 400, response.data)
+
+    def test_tls_created_on_app_create(self, mock_requests):
+        """
+        Ensure that a TLS object is created for an App with default values.
+
+        See https://github.com/deis/controller/issues/1042
+        """
+        app_id = self.create_app()
+        response = self.client.get('/v2/apps/{}/tls'.format(app_id))
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['https_enforced'], None)


### PR DESCRIPTION
This PR creates a TLS object when an application is created, fixing the issue where a server error is shown after `deis tls:info` is called after `deis create`.

closes #1042 
