### PR TITLE
fix(views): make sure domain is set it in cert attach operation

### DIFF
--- a/rootfs/api/tests/test_certificate_use_case_1.py
+++ b/rootfs/api/tests/test_certificate_use_case_1.py
@@ -92,6 +92,14 @@ class CertificateUseCase1Test(DeisTestCase):
         )
         self.assertEqual(response.status_code, 201, response.data)
 
+        # Attach domain to cert but post no body
+        response = self.client.post(
+            '{}/{}/domain/'.format(self.url, self.name),
+            {}
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data, {'detail': 'domain is a required field'})
+
         # Assert data
         response = self.client.get('{}/{}'.format(self.url, self.name))
         self.assertEqual(response.status_code, 200, response.data)

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -361,8 +361,11 @@ class CertificateViewSet(BaseDeisViewSet):
 
     def attach(self, request, *args, **kwargs):
         try:
-            # TODO how to validate domain is set in the body?
-            kwargs['domain'] = request.data['domain']
+            if kwargs['domain'] is None and not request.data.get('domain'):
+                raise DeisException("domain is a required field")
+            elif request.data.get('domain'):
+                kwargs['domain'] = request.data['domain']
+
             self.get_object().attach(*args, **kwargs)
         except Http404:
             raise


### PR DESCRIPTION
Made it so a user can pass /v2/apps/foo/domains/thing.com or pass {domain: thing.com} as the body
This works because DELETE uses the former format and POST (including SDK) use the latter but the URL format supports POST doing both... Should probably drop the body element at some point when we can break the API