### PR TITLE
chore(requirements): update django-guardian to 1.4.6

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -2,7 +2,7 @@
 backoff==1.3.1
 Django==1.10.1
 django-cors-middleware==1.3.1
-django-guardian==1.4.5
+django-guardian==1.4.6
 djangorestframework==3.4.6
 docker-py==1.9.0
 gunicorn==19.6.0


### PR DESCRIPTION
https://github.com/django-guardian/django-guardian/releases/tag/v1.4.6