### PR TITLE
ref(scheduler): move image pull policy settings from scheduler to App model and remove SLUG_RUNNER_IMAGE_PULL_POLICY

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -417,6 +417,9 @@ class App(UuidAuditedModel):
         # get application level pod termination grace period
         pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
 
+        # set the image pull policy that is associated with the application container
+        image_pull_policy = release.config.values.get('IMAGE_PULL_POLICY', settings.IMAGE_PULL_POLICY)  # noqa
+
         # create image pull secret if needed
         image_pull_secret_name = self.image_pull_secret(self.id, registry, image)
 
@@ -450,7 +453,13 @@ class App(UuidAuditedModel):
                 'deploy_timeout': deploy_timeout,
                 'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
                 'image_pull_secret_name': image_pull_secret_name,
+                'image_pull_policy': image_pull_policy
             }
+
+            # Check if it is a slug builder image.
+            if release.build.type == 'buildpack':
+                # overwrite image so slugrunner image is used in the container
+                image = settings.SLUGRUNNER_IMAGE
 
             # gather all proc types to be deployed
             tasks.append(
@@ -512,6 +521,9 @@ class App(UuidAuditedModel):
         # get application level pod termination grace period
         pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
 
+        # set the image pull policy that is associated with the application container
+        image_pull_policy = release.config.values.get('IMAGE_PULL_POLICY', settings.IMAGE_PULL_POLICY)  # noqa
+
         # create image pull secret if needed
         image_pull_secret_name = self.image_pull_secret(self.id, registry, image)
 
@@ -549,6 +561,7 @@ class App(UuidAuditedModel):
                 'release_summary': release.summary,
                 'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
                 'image_pull_secret_name': image_pull_secret_name,
+                'image_pull_policy': image_pull_policy
             }
 
         # Sort deploys so routable comes first
@@ -560,6 +573,10 @@ class App(UuidAuditedModel):
         try:
             # create the application config in k8s (secret in this case) for all deploy objects
             self._scheduler.set_application_config(self.id, envs, version)
+
+            if release.build.type == 'buildpack':
+                # overwrite image so slugrunner image is used in the container
+                image = settings.SLUGRUNNER_IMAGE
 
             # gather all proc types to be deployed
             tasks = [
@@ -778,6 +795,9 @@ class App(UuidAuditedModel):
         # get application level pod termination grace period
         pod_termination_grace_period_seconds = release.config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
 
+        # set the image pull policy that is associated with the application container
+        image_pull_policy = release.config.values.get('IMAGE_PULL_POLICY', settings.IMAGE_PULL_POLICY)  # noqa
+
         # create image pull secret if needed
         image_pull_secret_name = self.image_pull_secret(self.id, registry, image)
 
@@ -795,7 +815,13 @@ class App(UuidAuditedModel):
             'deploy_timeout': deploy_timeout,
             'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
             'image_pull_secret_name': image_pull_secret_name,
+            'image_pull_policy': image_pull_policy
         }
+
+        # Check if it is a slug builder image.
+        if release.build.type == 'buildpack':
+            # overwrite image so slugrunner image is used in the container
+            image = settings.SLUGRUNNER_IMAGE
 
         try:
             exit_code, output = self._scheduler.run(

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -254,7 +254,6 @@ BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', random_secret)
 
 # k8s image policies
 SLUGRUNNER_IMAGE = os.environ.get('SLUGRUNNER_IMAGE_NAME', 'quay.io/deisci/slugrunner:canary')  # noqa
-SLUG_RUNNER_IMAGE_PULL_POLICY = os.environ.get('SLUG_RUNNER_IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
 IMAGE_PULL_POLICY = os.environ.get('IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
 
 # Define a global default on how many pods to bring up and then

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -3,7 +3,6 @@ import operator
 import os
 import time
 
-from django.conf import settings
 from scheduler.exceptions import KubeException, KubeHTTPException
 from scheduler.resources import Resource
 from scheduler.states import PodState
@@ -110,9 +109,6 @@ class Pod(Resource):
         # How long until a pod is forcefully terminated. 30 is kubernetes default
         spec['terminationGracePeriodSeconds'] = kwargs.get('pod_termination_grace_period_seconds', 30)  # noqa
 
-        # set the image pull policy that is associated with the application container
-        kwargs['image_pull_policy'] = settings.IMAGE_PULL_POLICY
-
         # Check if it is a slug builder image.
         if build_type == "buildpack":
             # only buildpack apps need access to object storage
@@ -136,11 +132,6 @@ class Pod(Resource):
                 'mountPath': '/var/run/secrets/deis/objectstore/creds',
                 'readOnly': True
             }]
-
-            # overwrite image so slugrunner image is used in the container
-            image = settings.SLUGRUNNER_IMAGE
-            # slugrunner pull policy
-            kwargs['image_pull_policy'] = settings.SLUG_RUNNER_IMAGE_PULL_POLICY
 
         # create the base container
         container = {}


### PR DESCRIPTION
Removes the last of django.settings from scheduler main line code (not tests)

IMAGE_PULL_POLICY is now the only thing used and can be set per app, SLUG_RUNNER_IMAGE_PULL_POLICY has been removed