### PR TITLE
fix(api): cast DEPLOY_BATCHES and DEPLOY_TIMEOUT to int

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -996,16 +996,16 @@ class App(UuidAuditedModel):
         config = release.config
 
         # see if the app config has deploy batch preference, otherwise use global
-        batches = config.values.get('DEIS_DEPLOY_BATCHES', settings.DEIS_DEPLOY_BATCHES)
+        batches = int(config.values.get('DEIS_DEPLOY_BATCHES', settings.DEIS_DEPLOY_BATCHES))  # noqa
 
         # see if the app config has deploy timeout preference, otherwise use global
-        deploy_timeout = config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT)
+        deploy_timeout = int(config.values.get('DEIS_DEPLOY_TIMEOUT', settings.DEIS_DEPLOY_TIMEOUT))  # noqa
 
         # configures how many ReplicaSets to keep beside the latest version
         deployment_history = config.values.get('KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT', settings.KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT)  # noqa
 
         # get application level pod termination grace period
-        pod_termination_grace_period_seconds = config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS)  # noqa
+        pod_termination_grace_period_seconds = int(config.values.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', settings.KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS))  # noqa
 
         # set the image pull policy that is associated with the application container
         image_pull_policy = config.values.get('IMAGE_PULL_POLICY', settings.IMAGE_PULL_POLICY)

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -261,13 +261,13 @@ IMAGE_PULL_POLICY = os.environ.get('IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
 # Defaults to None, the default is to deploy to as many nodes as
 # the application has been instructed to run on
 # Can also be overwritten on per app basis if desired
-DEIS_DEPLOY_BATCHES = os.environ.get('DEIS_DEPLOY_BATCHES', None)
+DEIS_DEPLOY_BATCHES = int(os.environ.get('DEIS_DEPLOY_BATCHES', 0))
 
 # For old style deploys (RCs) defines how long each batch
 # (as defined by DEIS_DEPLOY_BATCHES) can take before giving up
 # For Kubernetes Deployments it is part of the global timeout
 # where it roughly goes BATCHES * TIMEOUT = global timeout
-DEIS_DEPLOY_TIMEOUT = os.environ.get('DEIS_DEPLOY_TIMEOUT', 120)
+DEIS_DEPLOY_TIMEOUT = int(os.environ.get('DEIS_DEPLOY_TIMEOUT', 120))
 
 KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT = os.environ.get('KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT', None)  # noqa
 


### PR DESCRIPTION
Otherwise it will be a string in the scheduler code and break it.

closes deis/builder#429