### PR TITLE
feat(api): inject release metadata into application

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -792,7 +792,10 @@ class App(UuidAuditedModel):
         # mix in default environment information deis may require
         default_env = {
             'DEIS_APP': self.id,
-            'WORKFLOW_RELEASE': 'v{}'.format(release.version)
+            'WORKFLOW_RELEASE': 'v{}'.format(release.version),
+            'WORKFLOW_RELEASE_SUMMARY': release.summary,
+            'WORKFLOW_RELEASE_CREATED_AT': str(release.created.strftime(
+                settings.DEIS_DATETIME_FORMAT))
         }
 
         # Check if it is a slug builder image.
@@ -802,6 +805,9 @@ class App(UuidAuditedModel):
             default_env['BUILDER_STORAGE'] = settings.APP_STORAGE
             default_env['DEIS_MINIO_SERVICE_HOST'] = settings.MINIO_HOST
             default_env['DEIS_MINIO_SERVICE_PORT'] = settings.MINIO_PORT
+
+        if release.build.sha:
+            default_env['SOURCE_VERSION'] = release.build.sha
 
         # fetch application port and inject into ENV vars as needed
         port = release.get_port()

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -582,16 +582,21 @@ class AppTest(DeisTestCase):
         url = "/v2/apps/{app.id}/builds".format(**locals())
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 201, response.data)
+        time_created = app.release_set.latest().created
         self.assertEqual(
             app._build_env_vars(app.release_set.latest()),
             {
                 'DEIS_APP': app.id,
                 'WORKFLOW_RELEASE': 'v2',
-                'PORT': 5000
+                'PORT': 5000,
+                'WORKFLOW_RELEASE_SUMMARY': 'autotest deployed autotest/example',
+                'WORKFLOW_RELEASE_CREATED_AT': str(time_created.strftime(
+                    settings.DEIS_DATETIME_FORMAT))
             })
         data['sha'] = 'abc1234'
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 201, response.data)
+        time_created = app.release_set.latest().created
         self.assertEqual(
             app._build_env_vars(app.release_set.latest()),
             {
@@ -601,7 +606,11 @@ class AppTest(DeisTestCase):
                 'SLUG_URL': 'autotest/example',
                 'BUILDER_STORAGE': None,
                 'DEIS_MINIO_SERVICE_HOST': '127.0.0.1',
-                'DEIS_MINIO_SERVICE_PORT': 80
+                'DEIS_MINIO_SERVICE_PORT': 80,
+                'SOURCE_VERSION': 'abc1234',
+                'WORKFLOW_RELEASE_SUMMARY': 'autotest deployed abc1234',
+                'WORKFLOW_RELEASE_CREATED_AT': str(time_created.strftime(
+                    settings.DEIS_DATETIME_FORMAT))
             })
 
     def test_gather_app_settings(self, mock_requests):


### PR DESCRIPTION
closes #1057 

rebased off of #1078 for the _build_env_vars tests, see e88c52f for the new commit.