### PR TITLE
Clarify PORT error when using private registry

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -153,7 +153,7 @@ class Release(UuidAuditedModel):
             if (creds is not None) or (settings.REGISTRY_LOCATION != 'on-cluster'):
                 if envs.get('PORT', None) is None:
                     raise DeisException(
-                        'PORT needs to be set in the config '
+                        'PORT needs to be set in the application config '
                         'when using a private registry'
                     )
 


### PR DESCRIPTION
I pulled my hair out for quite a bit of time because of the error I got, mentioned in deis/builder#433 

😄 

For me personally it would have helped if the error:

```
Error running git receive hook [publishing release (Unknown Error (400): {"detail":"PORT needs to be set in the config when using a private registry"})]
```

mentioned that it was about the application config, and not the registry config. Hence this pull request. Hope it helps others!

I'm not sure about convention, or I would have even put the URL to the corresponding docs in there, with a:

> See: https://deis.com/docs/workflow/installing-workflow/configuring-registry/#configuring-off-cluster-private-registry

Please let me know your thoughts and I can take care of that as well.

Cheers!