### PR TITLE
ref(registry): remove simpleflock and depend on Docker 1.9 minimum

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -15,6 +15,5 @@ pyOpenSSL==16.1.0
 pytz==2016.6.1
 requests==2.11.1
 requests-toolbelt==0.7.0
-simpleflock==0.0.3
 jsonschema==2.5.1
 idna==2.1


### PR DESCRIPTION
Concurrent pull issue was resolved in 1.9 (https://github.com/docker/docker/issues/9718) and Kubernetes is validated against that as well

I can update https://deis.com/docs/workflow/installing-workflow/system-requirements/ with the required info if we want to go with this change