### PR TITLE
feat(errors): give more context on what model is involved when 404 Not Found is involved

### DIFF
--- a/rootfs/api/exceptions.py
+++ b/rootfs/api/exceptions.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 import logging
 from rest_framework.compat import set_rollback
 from rest_framework.exceptions import APIException, status
@@ -28,7 +29,12 @@ class ServiceUnavailable(APIException):
 
 
 def custom_exception_handler(exc, context):
-    # Call REST framework's default exception handler first,
+    # give more context on the error since DRF masks it as Not Found
+    if isinstance(exc, Http404):
+        set_rollback()
+        return Response(str(exc), status=status.HTTP_404_NOT_FOUND)
+
+    # Call REST framework's default exception handler after specific 404 handling,
     # to get the standard error response.
     response = exception_handler(exc, context)
 

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -325,3 +325,9 @@ class ConfigTest(DeisTransactionTestCase):
         body = {'values': {'FOO': 'bar'}}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 403)
+
+    def test_config_app_not_exists(self, mock_requests):
+        url = '/v2/apps/{}/config'.format('fake')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data, 'No App matches the given query.')


### PR DESCRIPTION
Right now if you run a `deis config:list` outside of a deis repo you will still see a `Not Found` instead of a good message but that is due to how SDK / CLI handles errors.

I forced it to a random status code and get this back

```
deis config:list
Error: Unknown Error (418): {"detail":"Config was not found."}
```

Note that the app is missing but `Config` is the info since it happens within the config view, which is the only thing I get to plug into - Additionally there is no info about _what_ is missing if we were actually showing that App is missing. DAMN YOU DRF...

closes #893