### PR TITLE
fix(secret):create objectstore secret before calling scheduler deploy

### DIFF
--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -133,13 +133,6 @@ class Pod(Resource):
 
         # Check if it is a slug builder image.
         if build_type == "buildpack":
-            # only buildpack apps need access to object storage
-            try:
-                self.secret.get(namespace, 'objectstorage-keyfile')
-            except KubeException:
-                secret = self.secret.get('deis', 'objectstorage-keyfile').json()
-                self.secret.create(namespace, 'objectstorage-keyfile', secret['data'])
-
             # add the required volume to the top level pod spec
             spec['volumes'] = [{
                 'name': 'objectstorage-keyfile',


### PR DESCRIPTION
Create the objectstore secret before deploying as the current approach can cause 409 issues when multiple proctypes are present.
The error scenario can happen when moving from one k8s cluster to another cluster with external storage because of a cluster crash or any other reasons or during an upgrade from pre-deployments support in workflow(2.1/2/3) to latest.