### PR TITLE
docs(README): Recommend installing python 3.5 via pyenv on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,18 @@ apt-get install postgresql libpq-dev
 
 ### Python
 
-Python 3.5 is a minimum requirement and can be installed via `homebrew`:
+Python 3.5 is a minimum requirement and can be installed via `pyenv`:
 
 ```
-brew install python3
+brew install pyenv
+```
+
+- After installing, ensure [`eval "$(pyenv init -)"` is added to your shell startup.](https://github.com/yyuu/pyenv/#homebrew-on-mac-os-x)
+- Install and use Python 3.5:
+```
+pyenv install 3.5.0
+# if you have build issues, ensure Xcode CLI tools are installed:https://github.com/yyuu/pyenv/issues/451#issuecomment-151336786
+python local 3.5.0 # use Python 3.5.0 in your current directory
 ```
 
 Or via your package manager. For example, on Debian Jessie:


### PR DESCRIPTION
Installing Python 3.5 via Homebrew doesn't make it usable right away; python/pip 2.x via Homebrew will be used by default. More importantly, Homebrew isn't great at managing multiple versions of Python/Ruby/etc., but `pyenv` makes it easy to install and switch between Python versions.

I hit this issue attempting to setup my dev environment for this project; I think this will reduce the barrier to entry a bit.