### PR TITLE
docs(README) Refer to postgres setup in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ commit-hook:
 full-clean: check-docker
 	docker images -q $(IMAGE_PREFIX)$(COMPONENT) | xargs docker rmi -f
 
-postgres:
+postgres: check-docker
 	docker start postgres || docker run --restart="always" -d -p 5432:5432 --name postgres postgres:9.3
 	docker exec postgres createdb -U postgres deis 2>/dev/null || true
 	@echo "To use postgres for local development:"

--- a/README.md
+++ b/README.md
@@ -50,16 +50,11 @@ helmc install workflow-dev
 
 ### Postgresql
 
-Postgresql can be installed via `homebrew`:
-
+The application and tests use PostgreSQL. To start a local instance via Docker, run `make postgres` and set the following in your shell:
 ```
-brew install postgresql
-```
-
-Or via your package manager. For example, on Debian Jessie:
-
-```
-apt-get install postgresql libpq-dev
+  export PGHOST=`docker-machine ip $(docker-machine active) 2>/dev/null || echo 127.0.0.1`
+  export PGPORT=5432
+  export PGUSER=postgres
 ```
 
 ### Python


### PR DESCRIPTION
Remove instructions for installing PostgreSQL via Homebrew; also check that Docker is installed before executing `make postgres`.