### PR TITLE
fix(registration): allow admin user registration when the mode is admin_only

### DIFF
--- a/rootfs/api/permissions.py
+++ b/rootfs/api/permissions.py
@@ -2,7 +2,7 @@
 from rest_framework import exceptions
 from rest_framework import permissions
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, User
 
 from api import models
 
@@ -109,6 +109,8 @@ class HasRegistrationAuth(permissions.BasePermission):
             if settings.REGISTRATION_MODE == 'enabled':
                 return True
             elif settings.REGISTRATION_MODE == 'admin_only':
+                if not User.objects.filter(is_superuser=True).exists():
+                    return True
                 return request.user.is_superuser
             else:
                 raise Exception("{} is not a valid registation mode"

--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from rest_framework.authtoken.models import Token
+from django.test.utils import override_settings
 from api.tests import DeisTestCase
 
 
@@ -31,6 +32,21 @@ class TestAdminPerms(DeisTestCase):
         response = self.client.post(url, submit)
         self.assertEqual(response.status_code, 201, response.data)
         self.assertFalse(response.data['is_superuser'])
+
+    @override_settings(REGISTRATION_MODE="admin_only")
+    def test_first_signup_admin_only(self):
+        # register a first user
+        username, password = 'firstuser', 'password'
+        email = 'autotest@deis.io'
+        submit = {
+            'username': username,
+            'password': password,
+            'email': email,
+        }
+        url = '/v2/auth/register'
+        response = self.client.post(url, submit)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertTrue(response.data['is_superuser'])
 
     def test_list(self):
         submit = {


### PR DESCRIPTION
This can be a first step in providing different options on what the default registration mode can be.
Now the user can install workflow with `admin_only`  as default and register himself as the admin user without having to change the manifest after install.