### PR TITLE
chore(requirements): update to DRF 3.5.1

### DIFF
--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -216,6 +216,7 @@ class ConfigSerializer(serializers.ModelSerializer):
     class Meta:
         """Metadata options for a :class:`ConfigSerializer`."""
         model = models.Config
+        fields = '__all__'
 
     def validate_values(self, data):
         for key, value in data.items():
@@ -373,6 +374,7 @@ class ReleaseSerializer(serializers.ModelSerializer):
     class Meta:
         """Metadata options for a :class:`ReleaseSerializer`."""
         model = models.Release
+        fields = '__all__'
 
 
 class KeySerializer(serializers.ModelSerializer):
@@ -383,6 +385,7 @@ class KeySerializer(serializers.ModelSerializer):
     class Meta:
         """Metadata options for a KeySerializer."""
         model = models.Key
+        fields = '__all__'
 
 
 class DomainSerializer(serializers.ModelSerializer):
@@ -462,6 +465,7 @@ class CertificateSerializer(serializers.ModelSerializer):
             'key': {'write_only': True}
         }
         read_only_fields = ['common_name', 'fingerprint', 'san', 'domains', 'subject', 'issuer']
+        fields = '__all__'
 
 
 class PodSerializer(serializers.BaseSerializer):

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -3,7 +3,7 @@ backoff==1.3.1
 Django==1.10.2
 django-cors-middleware==1.3.1
 django-guardian==1.4.6
-djangorestframework==3.4.7
+djangorestframework==3.5.1
 docker-py==1.10.4
 gunicorn==19.6.0
 jmespath==0.9.0


### PR DESCRIPTION
http://www.django-rest-framework.org/topics/3.5-announcement

The lack of a fields class variable was causing problems. The lack of it was deprecated in 3.3 and finally removed in 3.5

Deprecates #1117