### PR TITLE
Ensure DEIS_DEBUG==true for debug output

### DIFF
--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -7,7 +7,7 @@
 set -eo pipefail
 
 # set debug based on envvar
-[[ $DEIS_DEBUG ]] && set -x
+[[ $DEIS_DEBUG == "true" ]] && set -x
 
 echo system information:
 echo "Django Version: $(./manage.py --version)"


### PR DESCRIPTION
Currently debug output is turned on if `DEIS_DEBUG` is set to anything (including `DEIS_DEBUG=FALSE`). This requires it be explicitly `true`, like the rest of the code base.

