### PR TITLE
fix(proctype): Change the regex used for validating proctypes

### DIFF
--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -18,7 +18,7 @@ from api import models
 
 # proc type name is alphanumeric
 # https://docs-v2.readthedocs.io/en/latest/using-workflow/process-types-and-the-procfile/#declaring-process-types
-PROCTYPE_MATCH = re.compile(r'^(?P<type>[a-z0-9]+)$')
+PROCTYPE_MATCH = re.compile(r'^(?P<type>[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*)$')
 MEMLIMIT_MATCH = re.compile(
     r'^(?P<mem>(([0-9]+(MB|KB|GB|[BKMG])|0)(/([0-9]+(MB|KB|GB|[BKMG])))?))$', re.IGNORECASE)
 CPUSHARE_MATCH = re.compile(

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -707,6 +707,41 @@ class BuildTest(DeisTransactionTestCase):
         }
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400, response.data)
+
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': {
+                'web': 'node server.js',
+                '-': 'node worker.js'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': {
+                'web': 'node server.js',
+                'worker-': 'node worker.js'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': {
+                'web': 'node server.js',
+                '-worker': 'node worker.js'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 400, response.data)
         # deploy app with empty command
         url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {
@@ -719,3 +754,15 @@ class BuildTest(DeisTransactionTestCase):
         }
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 400, response.data)
+
+        url = "/v2/apps/{app_id}/builds".format(**locals())
+        body = {
+            'image': 'autotest/example',
+            'sha': 'a'*40,
+            'procfile': {
+                'web': 'node server.js',
+                'Worker-test1': 'node worker.js'
+            }
+        }
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, 201, response.data)


### PR DESCRIPTION
fixes https://github.com/deis/controller/issues/1124

Not adding the regex to support underscore because kubernetes doesn't support it in the names and it is better to not add it than make changes internally from `_` to `-` which is might be prone to errors.

But if it is really important to have support for the `_` then i am open to adding it.