### PR TITLE
fix(port): Port can be made optional for non-routable apps

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -825,7 +825,8 @@ class App(UuidAuditedModel):
 
         # fetch application port and inject into ENV vars as needed
         port = release.get_port()
-        default_env['PORT'] = port
+        if port:
+            default_env['PORT'] = port
 
         # merge envs on top of default to make envs win
         default_env.update(release.config.values)

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -433,3 +433,15 @@ class ReleaseTest(DeisTransactionTestCase):
         ):
             release = app.release_set.latest()
             release.get_port()
+
+        # Set routable to false and port should be None instead of error
+        response = self.client.post(
+            '/v2/apps/{app.id}/settings'.format(**locals()),
+            {'routable': False}
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertFalse(app.appsettings_set.latest().routable)
+
+        release = app.release_set.latest()
+        port = release.get_port()
+        self.assertIsNone(port)


### PR DESCRIPTION
fixes #1015 

If the app is non-routable then don't throw error if port can't be found.