### PR TITLE
tests(scheduler): confirm "network unreachable" raises KubeHTTPException

### DIFF
--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -735,6 +735,11 @@ def put(request, context):
         context.status_code = 404
         context.reason = 'Not Found'
         return {}
+    # raise a 503 when we want to intentionally test for it
+    elif item['metadata']['name'] == 'image-pull-failed-test':
+        context.status_code = 503
+        context.reason = 'Network Unreachable'
+        return {}
 
     data = request.json()
 

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -88,6 +88,13 @@ class DeploymentsTest(TestCase):
             msg='failed to update Deployment foo in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
         ):
             self.update(self.namespace, 'foo')
+        name = 'image-pull-failed-test'
+        self.create(name=name)
+        with self.assertRaises(
+            KubeHTTPException,
+            msg='failed to update Deployment "{}": 503 Network Unreachable'.format(name)
+        ):
+            self.update(self.namespace, name)
 
     def test_update(self):
         # test success


### PR DESCRIPTION
This error occurs when the registry hosting the image being pulled by `deis pull` (or, in the case
of `git push deis master`, quay.io/deis/slugrunner) becomes unreachable. This test confirms that
master has fixed the original error, which is that a KubeException used to be raised, being
uncaught in older releases of Workflow. This has since been fixed in master by raising KubeHTTPException, which will raise the 503 and roll back the release rollout.