### PR TITLE
chore(requirements): update backoff library

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,5 +1,5 @@
 # Deis controller requirements
-backoff==1.3.1
+backoff==1.3.2
 Django==1.10.3
 django-cors-middleware==1.3.1
 django-guardian==1.4.6


### PR DESCRIPTION
See https://github.com/litl/backoff/releases/tag/v1.3.2