### PR TITLE
Add basic support of resource quotas for applications

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -215,7 +215,8 @@ class App(UuidAuditedModel):
                 quota_name = '{}-quota'.format(namespace)
                 self.log(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
                 quota_spec = json.loads(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
-                self.log('creating Quota {} for namespace {}'.format(quota_name, namespace), level=logging.DEBUG)
+                self.log('creating Quota {} for namespace {}'.format(quota_name, namespace),
+                         level=logging.DEBUG)
                 try:
                     self._scheduler.quota.get(namespace, quota_name)
                 except KubeException:

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -203,6 +203,7 @@ class App(UuidAuditedModel):
         # create required minimum resources in k8s for the application
         namespace = self.id
         service = self.id
+        quota_name = '{}-quota'.format(self.id)
         try:
             self.log('creating Namespace {} and services'.format(namespace), level=logging.DEBUG)
             # Create essential resources
@@ -212,8 +213,6 @@ class App(UuidAuditedModel):
                 self._scheduler.ns.create(namespace)
 
             if settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC != '':
-                quota_name = '{}-quota'.format(namespace)
-                self.log(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
                 quota_spec = json.loads(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
                 self.log('creating Quota {} for namespace {}'.format(quota_name, namespace),
                          level=logging.DEBUG)

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -211,6 +211,16 @@ class App(UuidAuditedModel):
             except KubeException:
                 self._scheduler.ns.create(namespace)
 
+            if settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC != '':
+                quota_name = '{}-quota'.format(namespace)
+                self.log(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
+                quota_spec = json.loads(settings.KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC)
+                self.log('creating Quota {} for namespace {}'.format(quota_name, namespace), level=logging.DEBUG)
+                try:
+                    self._scheduler.quota.get(namespace, quota_name)
+                except KubeException:
+                    self._scheduler.quota.create(namespace, quota_name, data=quota_spec)
+
             try:
                 self._scheduler.svc.get(namespace, service)
             except KubeException:

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -299,6 +299,9 @@ KUBERNETES_DEPLOYMENTS_REVISION_HISTORY_LIMIT = os.environ.get('KUBERNETES_DEPLO
 # How long k8s waits for a pod to finish work after a SIGTERM before sending SIGKILL
 KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS = int(os.environ.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', 30))  # noqa
 
+# Default quota spec for application namespace
+KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC = os.environ.get('KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC', '')  # noqa
+
 # registry settings
 REGISTRY_HOST = os.environ.get('DEIS_REGISTRY_SERVICE_HOST', '127.0.0.1')
 REGISTRY_PORT = os.environ.get('DEIS_REGISTRY_SERVICE_PORT', 5000)

--- a/rootfs/api/settings/testing.py
+++ b/rootfs/api/settings/testing.py
@@ -36,3 +36,4 @@ CACHES = {
 
 # How long k8s waits for a pod to finish work after a SIGTERM before sending SIGKILL
 KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS = int(os.environ.get('KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS', 2))  # noqa
+KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC = '{"spec":{"hard":{"pods":"10"}}}'

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -80,7 +80,7 @@ class CacheLock(object):
 resources = [
     'namespaces', 'nodes', 'pods', 'replicationcontrollers',
     'secrets', 'services', 'events', 'deployments', 'replicasets',
-    'horizontalpodautoscalers', 'scale',
+    'horizontalpodautoscalers', 'scale', 'resourcequotas'
 ]
 
 

--- a/rootfs/scheduler/resources/quota.py
+++ b/rootfs/scheduler/resources/quota.py
@@ -1,0 +1,48 @@
+from scheduler.exceptions import KubeHTTPException
+from scheduler.resources import Resource
+from scheduler.utils import dict_merge
+
+
+class Quota(Resource):
+    short_name = 'quota'
+
+    def get(self, namespace_name, name):
+        """
+        Fetch a single quota
+        """
+        url = '/namespaces/{}/resourcequotas/{}'.format(namespace_name, name)
+        message = 'get quota {} for namespace {}'.format(name, namespace_name)
+        url = self.api(url)
+        response = self.http_get(url)
+        if self.unhealthy(response.status_code):
+            raise KubeHTTPException(response, message)
+
+        return response
+
+    def create(self, namespace_name, name, **kwargs):
+        """
+        Create resource quota for namespace
+        """
+        url = self.api("/namespaces/{}/resourcequotas".format(namespace_name))
+        manifest = {
+            "kind": "ResourceQuota",
+            "apiVersion": "v1",
+            "metadata": {
+                "namespace": namespace_name,
+                "name": name,
+                'labels': {
+                    'app': namespace_name,
+                    'heritage': 'deis'
+                },
+            },
+            'spec': {}
+        }
+
+        data = dict_merge(manifest, kwargs.get('data', {}))
+        response = self.http_post(url, json=data)
+        if not response.status_code == 201:
+            raise KubeHTTPException(response,
+                                    "create quota {} for namespace {}".format(
+                                        name, namespace_name))
+
+        return response

--- a/rootfs/scheduler/tests/test_quota.py
+++ b/rootfs/scheduler/tests/test_quota.py
@@ -4,6 +4,7 @@ Unit tests for the Deis scheduler module.
 Run the tests with './manage.py test scheduler'
 """
 from scheduler.tests import TestCase
+from scheduler import KubeHTTPException
 
 
 class QuotaTest(TestCase):
@@ -25,3 +26,10 @@ class QuotaTest(TestCase):
         data = response.json()
         self.assertEqual(data.get('spec', {}), quota['spec'])
         self.assertEqual(data['metadata']['namespace'], namespace_name)
+
+    def test_create_with_nonexistent_namespace(self):
+        with self.assertRaises(
+            KubeHTTPException,
+            msg='failed to create quota test1 for namespace ghost-namespace: 404 Not Found'
+        ):
+            self.scheduler.quota.create('ghost-namespace', 'test1', data={})

--- a/rootfs/scheduler/tests/test_quota.py
+++ b/rootfs/scheduler/tests/test_quota.py
@@ -1,0 +1,27 @@
+"""
+Unit tests for the Deis scheduler module.
+
+Run the tests with './manage.py test scheduler'
+"""
+from scheduler.tests import TestCase
+
+
+class QuotaTest(TestCase):
+
+    def test_create_quota(self):
+        namespace_name = self.create_namespace()
+        quota = {
+            'spec': {
+                'hard': {
+                    'cpu': '3',
+                    'pods': '10',
+                    'secrets': '5'
+                }
+            }
+        }
+        self.scheduler.quota.create(namespace_name, 'test1', data=quota)
+
+        response = self.scheduler.quota.get(namespace_name, 'test1')
+        data = response.json()
+        self.assertEqual(data.get('spec', {}), quota['spec'])
+        self.assertEqual(data['metadata']['namespace'], namespace_name)


### PR DESCRIPTION
If set KUBERNETES_NAMESPACE_DEFAULT_QUOTA_SPEC to something like:
`{"spec":{"hard":{"cpu":"3","pods":"10","secrets":"10"}}}`
```json
{
    "spec": {
        "hard": {
            "cpu": "3",
            "pods": "10",
            "secrets": "10"
        }
    }
}
```
For all application namespaces will be added resource quota:
```bash
$ kubectl --namespace test20 get quota
NAME           AGE
test20-quota   35m
$ kubectl --namespace test20 get quota -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    labels:
      app: test20
      heritage: deis
    name: test20-quota
    namespace: test20
  spec:
    hard:
      cpu: "3"
      pods: "10"
      secrets: "10"
  status:
    hard:
      cpu: "3"
      pods: "10"
      secrets: "10"
    used:
      cpu: "0"
      pods: "0"
      secrets: "1"
kind: List
metadata: {}
```
We need this PR to restrict users from creation applications with a lot of resource usage. In our staging there are near 200+ applications and its count rise every month. This PR can save ops time and protect k8s nodes from overflow.

Documentation PR https://github.com/deis/workflow/pull/613
