### PR TITLE
chore(Makefile): remove pyvenv script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ postgres: check-docker
 	@echo "    export PGUSER=postgres"
 
 setup-venv:
-	@if [ ! -d venv ]; then pyvenv venv && source venv/bin/activate; fi
-	pip install --disable-pip-version-check -q -r rootfs/requirements.txt -r rootfs/dev_requirements.txt
+	python3 -m venv venv
+	venv/bin/pip3 install --disable-pip-version-check -q -r rootfs/requirements.txt -r rootfs/dev_requirements.txt
 
 test: test-style test-check test-unit test-functional
 


### PR DESCRIPTION
pyvenv has been officially deprecated in favour of `python3 -m venv` as of the python 3.6 announcement made this morning.

This command also works in previous python versions. I have manually tested this with python 3.5.2 without issues. The `@if [ ! -d venv ];` check is no longer necessary as the venv module identifies if it already exists and just exits zero.