### PR TITLE
fix(api): validate app name against k8s service regex

### DIFF
--- a/rootfs/api/migrations/0001_initial.py
+++ b/rootfs/api/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('uuid', api.fields.UuidField(auto_created=True, primary_key=True, serialize=False, editable=False, max_length=32, unique=True, verbose_name='UUID')),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('updated', models.DateTimeField(auto_now=True)),
-                ('id', models.SlugField(max_length=24, unique=True, null=True, validators=[api.models.validate_id_is_docker_compatible, api.models.validate_reserved_names])),
+                ('id', models.SlugField(max_length=24, unique=True, null=True, validators=[api.models.validate_app_id, api.models.validate_reserved_names])),
                 ('structure', jsonfield.fields.JSONField(default={}, blank=True, validators=[api.models.validate_app_structure])),
                 ('owner', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],

--- a/rootfs/api/migrations/0002_auto_20151215_0352.py
+++ b/rootfs/api/migrations/0002_auto_20151215_0352.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='app',
             name='id',
-            field=models.SlugField(max_length=24, unique=True, null=True, validators=[api.models.validate_id_is_docker_compatible, api.models.validate_reserved_names]),
+            field=models.SlugField(max_length=24, unique=True, null=True, validators=[api.models.validate_app_id, api.models.validate_reserved_names]),
         ),
         migrations.AlterField(
             model_name='app',

--- a/rootfs/api/models/__init__.py
+++ b/rootfs/api/models/__init__.py
@@ -113,7 +113,7 @@ class UuidAuditedModel(AuditedModel):
         abstract = True
 
 
-from .app import App, validate_id_is_docker_compatible, validate_reserved_names, validate_app_structure  # noqa
+from .app import App, validate_app_id, validate_reserved_names, validate_app_structure  # noqa
 from .appsettings import AppSettings  # noqa
 from .build import Build  # noqa
 from .certificate import Certificate, validate_certificate  # noqa

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -52,14 +52,14 @@ def get_session():
 
 
 # http://kubernetes.io/v1.1/docs/design/identifiers.html
-def validate_id_is_docker_compatible(value):
+def validate_app_id(value):
     """
     Check that the value follows the kubernetes name constraints
     """
-    match = re.match(r'^[a-z][a-z0-9-]*$', value)
+    match = re.match(r'[a-z]([a-z0-9-]*[a-z0-9])?$', value)
     if not match:
-        raise ValidationError("App name must start with an alphabetic character and can only "
-                              + "contain a-z (lowercase), 0-9 and hyphens.")
+        raise ValidationError("App name must start with an alphabetic character, cannot end with a"
+                              + " hyphen and can only contain a-z (lowercase), 0-9 and hyphens.")
 
 
 def validate_app_structure(value):
@@ -88,7 +88,7 @@ class App(UuidAuditedModel):
 
     owner = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
     id = models.SlugField(max_length=24, unique=True, null=True,
-                          validators=[validate_id_is_docker_compatible,
+                          validators=[validate_app_id,
                                       validate_reserved_names])
     structure = JSONField(default={}, blank=True, validators=[validate_app_structure])
 

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -56,9 +56,10 @@ def validate_id_is_docker_compatible(value):
     """
     Check that the value follows the kubernetes name constraints
     """
-    match = re.match(r'^[a-z0-9-]+$', value)
+    match = re.match(r'^[a-z][a-z0-9-]*$', value)
     if not match:
-        raise ValidationError("App name can only contain a-z (lowercase), 0-9 and hyphens")
+        raise ValidationError("App name must start with an alphabetic character and can only "
+                              + "contain a-z (lowercase), 0-9 and hyphens.")
 
 
 def validate_app_structure(value):

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -151,16 +151,24 @@ class AppTest(DeisTestCase):
         response = self.client.post('/v2/apps', {'id': 'camelCase'})
         self.assertContains(
             response,
-            'App name must start with an alphabetic character and can only contain a-z (lowercase)'
-            + ', 0-9 and hyphens.',
+            'App name must start with an alphabetic character, cannot end with a hyphen and can '
+            + 'only contain a-z (lowercase), 0-9 and hyphens.',
             status_code=400
         )
 
         response = self.client.post('/v2/apps', {'id': '123name-starts-with-numbers'})
         self.assertContains(
             response,
-            'App name must start with an alphabetic character and can only contain a-z (lowercase)'
-            + ', 0-9 and hyphens.',
+            'App name must start with an alphabetic character, cannot end with a hyphen and can '
+            + 'only contain a-z (lowercase), 0-9 and hyphens.',
+            status_code=400
+        )
+
+        response = self.client.post('/v2/apps', {'id': 'name-ends-with-hyphen-'})
+        self.assertContains(
+            response,
+            'App name must start with an alphabetic character, cannot end with a hyphen and can '
+            + 'only contain a-z (lowercase), 0-9 and hyphens.',
             status_code=400
         )
 

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -151,7 +151,16 @@ class AppTest(DeisTestCase):
         response = self.client.post('/v2/apps', {'id': 'camelCase'})
         self.assertContains(
             response,
-            'App name can only contain a-z (lowercase), 0-9 and hyphens',
+            'App name must start with an alphabetic character and can only contain a-z (lowercase)'
+            + ', 0-9 and hyphens.',
+            status_code=400
+        )
+
+        response = self.client.post('/v2/apps', {'id': '123name-starts-with-numbers'})
+        self.assertContains(
+            response,
+            'App name must start with an alphabetic character and can only contain a-z (lowercase)'
+            + ', 0-9 and hyphens.',
             status_code=400
         )
 


### PR DESCRIPTION
An application name must start with an alphabetic character and cannot end with a hyphen.

closes #1160 