### PR TITLE
fix(scheduler): use semver package to compare server version

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,6 +10,7 @@ jmespath==0.9.0
 jsonfield==1.0.3
 morph==0.1.2
 ndg-httpsclient==0.4.2
+packaging==16.8
 psycopg2==2.6.2
 pyOpenSSL==16.2.0
 pytz==2016.10

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from datetime import datetime
 import logging
+from packaging.version import Version
 import requests
 import requests.exceptions
 from requests_toolbelt import user_agent
@@ -77,13 +78,13 @@ class KubeHTTPClient(object):
         return object.__getattribute__(self, name)
 
     def version(self):
-        """Get Kubernetes version as a float"""
+        """Get Kubernetes version"""
         response = self.http_get('/version')
         if self.unhealthy(response.status_code):
             raise KubeHTTPException(response, 'fetching Kubernetes version')
 
         data = response.json()
-        return float('{}.{}'.format(data['major'], data['minor']))
+        return Version('{}.{}'.format(data['major'], data['minor']))
 
     @staticmethod
     def parse_date(date):

--- a/rootfs/scheduler/resources/horizontalpodautoscaler.py
+++ b/rootfs/scheduler/resources/horizontalpodautoscaler.py
@@ -1,4 +1,6 @@
 import json
+from packaging.version import parse
+
 from scheduler.resources import Resource
 from scheduler.exceptions import KubeException, KubeHTTPException
 
@@ -11,7 +13,7 @@ class HorizontalPodAutoscaler(Resource):
     def api_version(self):
         # API location changes between versions
         # http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/#api-object
-        if self.version() >= 1.3:
+        if self.version() >= parse("1.3.0"):
             return 'autoscaling/v1'
 
         # 1.2 and older
@@ -69,7 +71,7 @@ class HorizontalPodAutoscaler(Resource):
             }
         }
 
-        if self.version() >= 1.3:
+        if self.version() >= parse("1.3.0"):
             manifest['spec']['targetCPUUtilizationPercentage'] = cpu_percent
 
             manifest['spec']['scaleTargetRef'] = {
@@ -77,7 +79,7 @@ class HorizontalPodAutoscaler(Resource):
                 'kind': target['kind'],
                 'name': target['metadata']['name'],
             }
-        elif self.version() <= 1.2:
+        elif self.version() <= parse("1.2.0"):
             # api changed between version
             manifest['spec']['cpuUtilization'] = {
                 'targetPercentage': cpu_percent
@@ -149,10 +151,10 @@ class HorizontalPodAutoscaler(Resource):
         # ideally it would use the resources wait commands but they vary
         for _ in range(30):
             # fetch resource attached to it
-            if self.version() >= 1.3:
+            if self.version() >= parse("1.3.0"):
                 resource_kind = hpa['spec']['scaleTargetRef']['kind'].lower()
                 resource_name = hpa['spec']['scaleTargetRef']['name']
-            elif self.version() <= 1.2:
+            elif self.version() <= parse("1.2.0"):
                 resource_kind = hpa['spec']['scaleRef']['kind'].lower()
                 resource_name = hpa['spec']['scaleRef']['name']
 

--- a/rootfs/scheduler/tests/test_horizontalpodautoscaler_12_lower.py
+++ b/rootfs/scheduler/tests/test_horizontalpodautoscaler_12_lower.py
@@ -3,13 +3,15 @@ Unit tests for the Deis scheduler module.
 
 Run the tests with './manage.py test scheduler'
 """
+from packaging.version import Version
 from unittest import mock
+
 from scheduler import KubeHTTPException, KubeException
 from scheduler.tests import TestCase
 from scheduler.utils import generate_random_name
 
 
-@mock.patch('scheduler.KubeHTTPClient.version', lambda *args: 1.2)
+@mock.patch('scheduler.KubeHTTPClient.version', lambda *args: Version('1.2'))
 class HorizontalPodAutoscalersTest(TestCase):
     """Tests scheduler horizontalpodautoscaler calls"""
 


### PR DESCRIPTION
Since the server version can be any valid string type, it is incorrect to assume that the minor
version can be converted into a float value. Instead, it is better to compare it as a string using
the semver package.

closes #1159.