### PR TITLE
chore(codecov): delete codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,0 @@
-# documentation is at https://codecov.io/gh/deis/controller/settings/yaml
-comment:
-  layout: header, diff
-coverage:
-  status:
-    changes: false


### PR DESCRIPTION
There is nothing more infuriating than a PR that goes red because the coverage dropped by 0.05%
because some code was shifted around. I propose removing it entirely from the project.