### PR TITLE
fix(boot): Don't change group ownership of docker socket

### DIFF
--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -16,12 +16,16 @@ python --version
 mkdir -p /app/data/logs
 chmod -R 777 /app/data/logs
 
-# HACK(bacongobbler): explicitly add the docker socket to the deis group
-chgrp deis /var/run/docker.sock
-
-# allow deis user group permission to Docker socket
-groupadd -g "$(stat -c "%g" /var/run/docker.sock)" docker || true
-usermod -a -G docker deis || true
+# modify deis user groups to grant access to Docker socket
+DOCKER_SOCKET_GID=$(stat -c "%g" /var/run/docker.sock)
+DOCKER_SOCKET_GROUP=$(getent group "$DOCKER_SOCKET_GID" | cut -d : -f 1 || :)
+if [[ -z "$DOCKER_SOCKET_GROUP" ]]; then
+  DOCKER_SOCKET_GROUP=docker
+  groupadd -g "$DOCKER_SOCKET_GID" "$DOCKER_SOCKET_GROUP"
+fi
+if [[ "$DOCKER_SOCKET_GROUP" != "deis" ]]; then
+  usermod -a -G "$DOCKER_SOCKET_GROUP" deis
+fi
 
 echo ""
 echo "Django checks:"


### PR DESCRIPTION
This is a better fix for issue #804 and fixes #1170:

* The gid of the docker socket is no longer changed to that of the deis group (gid 107).
* If an existing group in the container has the same gid as the socket, we add the deis user to that group (unless of course it is the "deis" group).
* If no such group exists, we create a new "docker" group and add the user to that (like before @bacongobbler's hack in b27c816e9ef21a989c68db23c0c98c02f726cf7b was added, which effectively disabled this code).
