### PR TITLE
fix(domain): remove the annotation when domain is deleted

### DIFF
--- a/rootfs/api/models/domain.py
+++ b/rootfs/api/models/domain.py
@@ -49,6 +49,10 @@ class Domain(AuditedModel):
         app = str(self.app)
         domain = str(self.domain)
 
+        # Deatch cert, updates k8s
+        if self.certificate:
+            self.certificate.detach(domain=domain)
+
         # get config for the service
         config = self._load_service_config(app, 'router')
 
@@ -63,10 +67,6 @@ class Domain(AuditedModel):
         config['domains'] = ','.join(domains)
 
         self._save_service_config(app, 'router', config)
-
-        # Deatch cert, updates k8s
-        if self.certificate:
-            self.certificate.detach(domain=str(self.domain))
 
         # Delete from DB
         return super(Domain, self).delete(*args, **kwargs)


### PR DESCRIPTION
fixes #1172 

certificate.detach() calls domain.save() which updates the service annotation with the domain again.Hence remove the domain annotation after detaching the certificate.