### PR TITLE
fix(api): account for NoneType when resource is gone

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -281,9 +281,10 @@ class App(UuidAuditedModel):
                 desired = 0
                 labels = self._scheduler_filter(**kwargs)
                 # fetch RS (which represent Deployments)
-                controllers = self._scheduler.rs.get(kwargs['id'], labels=labels)
-
-                for controller in controllers.json()['items']:
+                controllers = self._scheduler.rs.get(kwargs['id'], labels=labels).json()['items']
+                if not controllers:
+                    controllers = []
+                for controller in controllers:
                     desired += controller['spec']['replicas']
         except KubeException:
             # Nothing was found
@@ -737,6 +738,8 @@ class App(UuidAuditedModel):
                 pods = [self._scheduler.pod.get(self.id, kwargs['name']).json()]
             else:
                 pods = self._scheduler.pod.get(self.id, labels=labels).json()['items']
+                if not pods:
+                    pods = []
 
             data = []
             for p in pods:

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -605,6 +605,10 @@ def fetch_all(request, context):
     filters = prepare_query_filters(url.query)
     cache_path = cache_key(request.path)
     data = filter_data(filters, cache_path)
+    # HACK(bacongobbler): in kubernetes v1.5, fetching a list of resources returns a NoneType
+    # instead of an empty list.
+    if not data:
+        data = None
     return {'items': data}
 
 

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -224,7 +224,7 @@ class Deployment(Resource):
         # fetch the latest RS for Deployment and use the start time to compare to deploy timeout
         replicasets = self.rs.get(namespace, labels=labels).json()['items']
         # the labels should ensure that only 1 replicaset due to the version label
-        if len(replicasets) != 1:
+        if replicasets and len(replicasets) != 1:
             # if more than one then sort by start time to newest is first
             replicasets.sort(key=lambda x: x['metadata']['creationTimestamp'], reverse=True)
 
@@ -356,7 +356,8 @@ class Deployment(Resource):
         # if there is no batch information available default to available nodes for app
         if not batches:
             # figure out how many nodes the application can go on
-            steps = len(self.node.get(labels=tags).json()['items'])
+            nodes = self.node.get(labels=tags).json()['items']
+            steps = len(nodes) if nodes else 0
         else:
             steps = int(batches)
 

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -124,6 +124,12 @@ class DeploymentsTest(TestCase):
         self.assertEqual(response.status_code, 200, data)
 
     def test_get_deployments(self):
+        # test when no deployments exist
+        response = self.scheduler.deployment.get(self.namespace)
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIn('items', data)
+        self.assertEqual(data['items'], None)
         # test success
         name = self.create()
         response = self.scheduler.deployment.get(self.namespace)


### PR DESCRIPTION
In versions prior to Kubernetes v1.5, an empty list was returned when a resource didn't exist. in
v1.5 it now returns a NoneType, so we need to account for that change and convert it back to an
empty list.

fixes #1175 