### PR TITLE
fix(perms):Use the same regex for perms as auth endpoint

### DIFF
--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -134,7 +134,7 @@ class TestAdminPerms(DeisTestCase):
         self.assertTrue(response.data['is_superuser'])
 
         submit = {
-            'username': 'second',
+            'username': 'second.lastname',
             'password': 'password',
             'email': 'autotest@deis.io',
         }
@@ -148,12 +148,12 @@ class TestAdminPerms(DeisTestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         # grant user 2 the superuser perm
         url = '/v2/admin/perms'
-        body = {'username': 'second'}
+        body = {'username': 'second.lastname'}
         response = self.client.post(url, body)
         self.assertEqual(response.status_code, 201, response.data)
 
         # revoke the superuser perm
-        response = self.client.delete(url + '/second')
+        response = self.client.delete(url + '/second.lastname')
         self.assertEqual(response.status_code, 204, response.data)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200, response.data)

--- a/rootfs/api/urls.py
+++ b/rootfs/api/urls.py
@@ -106,7 +106,7 @@ urlpatterns = [
     url(r'^auth/tokens/$',
         views.TokenManagementViewSet.as_view({'post': 'regenerate'})),
     # admin sharing
-    url(r'^admin/perms/(?P<username>[-_\w]+)/?$',
+    url(r'^admin/perms/(?P<username>[\w.@+-]+)/?$',
         views.AdminPermsViewSet.as_view({'delete': 'destroy'})),
     url(r'^admin/perms/?$',
         views.AdminPermsViewSet.as_view({'get': 'list', 'post': 'create'})),


### PR DESCRIPTION
fixes #1180 
There are no restrictions while creating users and hence there should be any while changing the perms of the user.