### PR TITLE
Handle cases with namespace quotas limits sets

### DIFF
--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -551,7 +551,7 @@ def filter_data(filters, path):
             continue
 
         # check if item has labels
-        if 'labels' not in item['metadata']:
+        if 'labels' not in item['metadata'] and item['kind'] != 'Event':
             continue
 
         # Do extra filtering based on labelSelector

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -237,6 +237,12 @@ class Deployment(Resource):
             self.log(namespace, 'Deploy operation for Deployment {} in has expired. Rolling back to last good known release'.format(name), level='DEBUG')  # noqa
             return False, True
 
+        try:
+            self._check_for_failed_events(namespace, labels=labels)
+        except KubeException as e:
+            self.log(namespace, e)
+            return False, True
+
         return True, False
 
     def are_replicas_ready(self, namespace, name):

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -326,6 +326,9 @@ class Deployment(Resource):
         timeout = len(batches) * deploy_timeout
         self.log(namespace, 'This deployments overall timeout is {}s - batch timout is {}s and there are {} batches to deploy with a total of {} pods'.format(timeout, deploy_timeout, len(batches), replicas))  # noqa
 
+        # check for failed events(when quota exceeded for example)
+        self._check_for_failed_events(namespace, labels=labels)
+
         waited = 0
         while waited < timeout:
             ready, availablePods = self.are_replicas_ready(namespace, name)
@@ -351,6 +354,39 @@ class Deployment(Resource):
         ready, _ = self.are_replicas_ready(namespace, name)
         if not ready:
             self.pod._handle_not_ready_pods(namespace, labels)
+
+    def _check_for_failed_events(self, namespace, labels):
+        """
+        Request for new ReplicaSet of Deployment and search for failed events involved by that RS
+        Raises: KubeException when RS have events with FailedCreate reason
+        """
+        response = self.rs.get(namespace, labels=labels)
+        data = response.json()
+        fields = {
+            'involvedObject.kind': 'ReplicaSet',
+            'involvedObject.name': data['items'][0]['metadata']['name'],
+            'involvedObject.namespace': namespace,
+            'involvedObject.uid': data['items'][0]['metadata']['uid'],
+        }
+        events_list = self.ns.events(namespace, fields=fields).json()
+        events = events_list.get('items', [])
+        if events is not None and len(events) != 0:
+            for event in events:
+                if event['reason'] == 'FailedCreate':
+                    log = self._get_formatted_messages(events)
+                    self.log(namespace, log)
+                    raise KubeException(log)
+
+    @staticmethod
+    def _get_formatted_messages(events):
+        """
+        Format each event by string and join all events to one string
+        """
+        message_format = 'Message:{message}, lastTimestamp:{lastTimestamp}, reason: {reason}, count: {count}'  # noqa
+        output = []
+        for event in events:
+            output.append(message_format.format(**event))
+        return '\n'.join(output)
 
     def _get_deploy_steps(self, batches, tags):
         # if there is no batch information available default to available nodes for app

--- a/rootfs/scheduler/resources/events.py
+++ b/rootfs/scheduler/resources/events.py
@@ -1,0 +1,46 @@
+from scheduler.exceptions import KubeHTTPException
+from scheduler.resources import Resource
+from datetime import datetime
+import uuid
+
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
+
+class Events(Resource):
+    """
+    Events resource.
+    Warning! Used ONLY for testing purposes
+    """
+    short_name = 'ev'
+
+    def create(self, namespace, name, message, **kwargs):
+        url = self.api('/namespaces/{}/events'.format(namespace))
+        data = {
+            'kind': 'Event',
+            'apiVersion': 'v1',
+            'count': kwargs.get('count', 1),
+            'metadata': {
+                'creationTimestamp': datetime.now().strftime(DATETIME_FORMAT),
+                'namespace': namespace,
+                'name': name,
+                'resourceVersion': kwargs.get('resourceVersion', ''),
+                'uid': str(uuid.uuid4()),
+            },
+            'message': message,
+            'type': kwargs.get('type', 'Normal'),
+            'firstTimestamp': datetime.now().strftime(DATETIME_FORMAT),
+            'lastTimestamp': datetime.now().strftime(DATETIME_FORMAT),
+            'reason': kwargs.get('reason', ''),
+            'source': {
+                'component': kwargs.get('component', ''),
+            },
+            'involvedObject': kwargs.get('involvedObject', {})
+        }
+
+        response = self.http_post(url, json=data)
+        if not response.status_code == 201:
+            raise KubeHTTPException(response, 'create Event for namespace {}'.format(namespace))  # noqa
+
+        return response
+
+

--- a/rootfs/scheduler/resources/events.py
+++ b/rootfs/scheduler/resources/events.py
@@ -42,5 +42,3 @@ class Events(Resource):
             raise KubeHTTPException(response, 'create Event for namespace {}'.format(namespace))  # noqa
 
         return response
-
-

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -732,7 +732,7 @@ class Pod(Resource):
             self.log(namespace, log)
             raise KubeException(log)
         else:
-            raise RuntimeError('Unable to start pods, no events in namespace found.')  # noqa
+            return None
 
     def _get_namespace_events(self, namespace, event_type='Warning'):
         """

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -719,7 +719,41 @@ class Pod(Resource):
                     message = "\n".join([x.strip() for x in event['message'].split("\n")])
                     raise KubeException(message)
 
-        return None
+        # Handle cases when no one pods is started (quota check fialed)
+        # If quota is enabled in a namespace for compute resources like cpu and
+        # memory, users must specify requests or limits for those values;
+        # otherwise, the quota system may reject pod creation.
+        # http://kubernetes.io/docs/admin/resourcequota/
+        # or when scale process trigger overuse case for some pods:
+        # For example: used 3/3 pods, but user scale to 4
+        events = self._get_namespace_events(namespace)
+        if len(events) != 0:
+            log = self._get_formatted_messages(events)
+            self.log(namespace, log)
+            raise KubeException(log)
+        else:
+            raise RuntimeError('Unable to start pods, no events in namespace found.')  # noqa
+
+    def _get_namespace_events(self, namespace, event_type='Warning'):
+        """
+        Get events of namespace by event_type (default Warning)
+        http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_event
+        """
+        response = self.ns.events(namespace).json()
+        events = response.get('items', [])
+        return list(filter(lambda event: event.get('type', '') == event_type,
+                           events))
+
+    @staticmethod
+    def _get_formatted_messages(events):
+        """
+        Format each event by string and join all events to one string
+        """
+        message_format = 'Message:{message}, lastTimestamp:{lastTimestamp}, reason: {reason}, count: {count}'  # noqa
+        output = []
+        for event in events:
+            output.append(message_format.format(**event))
+        return '\n'.join(output)
 
     def deploy_probe_timeout(self, timeout, namespace, labels, containers):
         """

--- a/rootfs/scheduler/tests/test_pods.py
+++ b/rootfs/scheduler/tests/test_pods.py
@@ -5,7 +5,7 @@ Run the tests with './manage.py test scheduler'
 """
 from unittest import mock
 from datetime import datetime, timedelta
-from scheduler import KubeHTTPException
+from scheduler import KubeHTTPException, KubeException
 from scheduler.tests import TestCase
 from scheduler.utils import generate_random_name
 
@@ -37,7 +37,8 @@ class PodsTest(TestCase):
     def test_create_failure(self):
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to create Pod doesnotexist in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
+            msg='failed to create Pod doesnotexist in Namespace {}: 404 Not Found'.format(
+                self.namespace)  # noqa
         ):
             self.create('doesnotexist', 'doesnotexist')
 
@@ -48,7 +49,8 @@ class PodsTest(TestCase):
         # test failure
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to delete Pod foo in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
+            msg='failed to delete Pod foo in Namespace {}: 404 Not Found'.format(
+                self.namespace)  # noqa
         ):
             self.scheduler.pod.delete(self.namespace, 'foo')
 
@@ -74,7 +76,8 @@ class PodsTest(TestCase):
         # test failure
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to get Pod doesnotexist in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
+            msg='failed to get Pod doesnotexist in Namespace {}: 404 Not Found'.format(
+                self.namespace)  # noqa
         ):
             self.scheduler.pod.get(self.namespace, 'doesnotexist')
 
@@ -120,7 +123,8 @@ class PodsTest(TestCase):
 
         # on a newly created pod has been deleted with ready state on a container
         pod['metadata']['deletionTimestamp'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod),
+                         'Terminating')
         del pod['metadata']['deletionTimestamp']
 
         # now say the app container is not Ready
@@ -134,12 +138,14 @@ class PodsTest(TestCase):
         # verify Terminating status
         del container['state']['running']
         container['state']['terminated'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod),
+                         'Terminating')
 
         # test metdata terminating
         del container['state']['terminated']
         pod['metadata']['deletionTimestamp'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod),
+                         'Terminating')
         del pod['metadata']['deletionTimestamp']
 
         # inject fake state
@@ -161,22 +167,26 @@ class PodsTest(TestCase):
         # only pod but no other probe
         pod['status']['phase'] = 'Running'
         # fake out functions for failure
-        with mock.patch('scheduler.resources.pod.Pod.readiness_status') as ready:
+        with mock.patch(
+            'scheduler.resources.pod.Pod.readiness_status') as ready:
             ready.return_value = 'Starting'
 
             # only readiness is ready so overall ready status is False
             self.assertFalse(self.scheduler.pod.ready(pod))
 
-            with mock.patch('scheduler.resources.pod.Pod.liveness_status') as liveness:
+            with mock.patch(
+                'scheduler.resources.pod.Pod.liveness_status') as liveness:
                 liveness.return_value = False
 
                 # all things have lined up, go time
                 self.assertFalse(self.scheduler.pod.ready(pod))
 
         # fake out other functions since they are tested by themselves
-        with mock.patch('scheduler.resources.pod.Pod.readiness_status') as ready:
+        with mock.patch(
+            'scheduler.resources.pod.Pod.readiness_status') as ready:
             ready.return_value = 'Running'
-            with mock.patch('scheduler.resources.pod.Pod.liveness_status') as liveness:
+            with mock.patch(
+                'scheduler.resources.pod.Pod.liveness_status') as liveness:
                 # keep liveness as failing for now
                 liveness.return_value = False
 
@@ -197,5 +207,16 @@ class PodsTest(TestCase):
 
         # set deleted 10 minutes in the past
         ts_deleted = datetime.utcnow() - timedelta(minutes=10)
-        pod['metadata']['deletionTimestamp'] = ts_deleted.strftime(self.scheduler.DATETIME_FORMAT)
+        pod['metadata']['deletionTimestamp'] = ts_deleted.strftime(
+            self.scheduler.DATETIME_FORMAT)
         self.assertTrue(self.scheduler.pod.deleted(pod))
+
+    def test_limits_failure(self):
+        message = generate_random_name()
+        self.scheduler.ev.create(self.namespace,
+                                 '{}'.format(generate_random_name()),
+                                 message, type='Warning')
+        with self.assertRaisesRegex(KubeException,
+                                    'Message:{}.*'.format(message)):
+            self.scheduler.pod._handle_not_ready_pods(self.namespace, {})
+

--- a/rootfs/scheduler/tests/test_pods.py
+++ b/rootfs/scheduler/tests/test_pods.py
@@ -5,7 +5,7 @@ Run the tests with './manage.py test scheduler'
 """
 from unittest import mock
 from datetime import datetime, timedelta
-from scheduler import KubeHTTPException, KubeException
+from scheduler import KubeHTTPException
 from scheduler.tests import TestCase
 from scheduler.utils import generate_random_name
 
@@ -199,12 +199,3 @@ class PodsTest(TestCase):
         ts_deleted = datetime.utcnow() - timedelta(minutes=10)
         pod['metadata']['deletionTimestamp'] = ts_deleted.strftime(self.scheduler.DATETIME_FORMAT)
         self.assertTrue(self.scheduler.pod.deleted(pod))
-
-    def test_limits_failure(self):
-        message = generate_random_name()
-        self.scheduler.ev.create(self.namespace,
-                                 '{}'.format(generate_random_name()),
-                                 message, type='Warning')
-        with self.assertRaisesRegex(KubeException,
-                                    'Message:{}.*'.format(message)):
-            self.scheduler.pod._handle_not_ready_pods(self.namespace, {})

--- a/rootfs/scheduler/tests/test_pods.py
+++ b/rootfs/scheduler/tests/test_pods.py
@@ -37,8 +37,7 @@ class PodsTest(TestCase):
     def test_create_failure(self):
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to create Pod doesnotexist in Namespace {}: 404 Not Found'.format(
-                self.namespace)  # noqa
+            msg='failed to create Pod doesnotexist in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
         ):
             self.create('doesnotexist', 'doesnotexist')
 
@@ -49,8 +48,7 @@ class PodsTest(TestCase):
         # test failure
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to delete Pod foo in Namespace {}: 404 Not Found'.format(
-                self.namespace)  # noqa
+            msg='failed to delete Pod foo in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
         ):
             self.scheduler.pod.delete(self.namespace, 'foo')
 
@@ -76,8 +74,7 @@ class PodsTest(TestCase):
         # test failure
         with self.assertRaises(
             KubeHTTPException,
-            msg='failed to get Pod doesnotexist in Namespace {}: 404 Not Found'.format(
-                self.namespace)  # noqa
+            msg='failed to get Pod doesnotexist in Namespace {}: 404 Not Found'.format(self.namespace)  # noqa
         ):
             self.scheduler.pod.get(self.namespace, 'doesnotexist')
 
@@ -123,8 +120,7 @@ class PodsTest(TestCase):
 
         # on a newly created pod has been deleted with ready state on a container
         pod['metadata']['deletionTimestamp'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod),
-                         'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
         del pod['metadata']['deletionTimestamp']
 
         # now say the app container is not Ready
@@ -138,14 +134,12 @@ class PodsTest(TestCase):
         # verify Terminating status
         del container['state']['running']
         container['state']['terminated'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod),
-                         'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
 
         # test metdata terminating
         del container['state']['terminated']
         pod['metadata']['deletionTimestamp'] = 'fake'
-        self.assertEqual(self.scheduler.pod.readiness_status(pod),
-                         'Terminating')
+        self.assertEqual(self.scheduler.pod.readiness_status(pod), 'Terminating')
         del pod['metadata']['deletionTimestamp']
 
         # inject fake state
@@ -167,26 +161,22 @@ class PodsTest(TestCase):
         # only pod but no other probe
         pod['status']['phase'] = 'Running'
         # fake out functions for failure
-        with mock.patch(
-            'scheduler.resources.pod.Pod.readiness_status') as ready:
+        with mock.patch('scheduler.resources.pod.Pod.readiness_status') as ready:
             ready.return_value = 'Starting'
 
             # only readiness is ready so overall ready status is False
             self.assertFalse(self.scheduler.pod.ready(pod))
 
-            with mock.patch(
-                'scheduler.resources.pod.Pod.liveness_status') as liveness:
+            with mock.patch('scheduler.resources.pod.Pod.liveness_status') as liveness:
                 liveness.return_value = False
 
                 # all things have lined up, go time
                 self.assertFalse(self.scheduler.pod.ready(pod))
 
         # fake out other functions since they are tested by themselves
-        with mock.patch(
-            'scheduler.resources.pod.Pod.readiness_status') as ready:
+        with mock.patch('scheduler.resources.pod.Pod.readiness_status') as ready:
             ready.return_value = 'Running'
-            with mock.patch(
-                'scheduler.resources.pod.Pod.liveness_status') as liveness:
+            with mock.patch('scheduler.resources.pod.Pod.liveness_status') as liveness:
                 # keep liveness as failing for now
                 liveness.return_value = False
 
@@ -207,8 +197,7 @@ class PodsTest(TestCase):
 
         # set deleted 10 minutes in the past
         ts_deleted = datetime.utcnow() - timedelta(minutes=10)
-        pod['metadata']['deletionTimestamp'] = ts_deleted.strftime(
-            self.scheduler.DATETIME_FORMAT)
+        pod['metadata']['deletionTimestamp'] = ts_deleted.strftime(self.scheduler.DATETIME_FORMAT)
         self.assertTrue(self.scheduler.pod.deleted(pod))
 
     def test_limits_failure(self):
@@ -219,4 +208,3 @@ class PodsTest(TestCase):
         with self.assertRaisesRegex(KubeException,
                                     'Message:{}.*'.format(message)):
             self.scheduler.pod._handle_not_ready_pods(self.namespace, {})
-


### PR DESCRIPTION
# Overview
This PR handle 2 specific cases:
- User did not set quota for applications or set it incorrectly
- User tries to scale the application when limits are already exceeded (overuse)

# Problem
Аdmin set default quota for namespaces (memory request and limit to1024M).
User tries to deploy application my-shiny-app (w/o setting limits for application): git push deis master
Deis controller return success after build and launch, but actually no pods are started because kubernates rejects pods creation.
Kubernates controller manager add event message to namespace with description:
```
Error creating: pods "my-shiny-app-web-1758015041-" is forbidden: failed quota: my-shiny-app-quota: must specify limits.memory,requests.memory
```
If quota is enabled in a namespace for compute resources like cpu and memory, users must specify requests or limits for those values; otherwise, the quota system may reject pod creation. 
Source: http://kubernetes.io/docs/admin/resourcequota/

Similar description when user set limits, but due to overuse next happened:
```
Error creating: pods "my-shiny-app-web-3136383174-" is forbidden: exceeded quota: my-shiny-app-quota, requested: requests.memory=600Mi, used: requests.memory=400Mi, limited: requests.memory=800Mi
```

So, user or CI/CD script make sure, that all are correct. But in fact, some actions needed from user.

# Solution
Explicit error return code with descriptive message for this situation.
