### PR TITLE
ref(codecov): add 0.2% failure threshold to codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,7 @@ comment:
   layout: header, diff
 coverage:
   status:
+    project:
+      default:
+        threshold: 0.2
     changes: false


### PR DESCRIPTION
This way, changes that drop coverage by less than a fifth of a percent will still pass. Anything
more than that should be looked at more closely by the reviewer for more potential places to cover
with tests.

This is mostly so that small PRs that shuffle some code around won't fail. As a reference point for how large 0.2% is in terms of code coverage, PRs like #1191 will still fail.