### PR TITLE
fix(charts): pipeline time_zone value to quote func

### DIFF
--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: "IMAGE_PULL_POLICY"
               value: "{{ .Values.app_pull_policy }}"
             - name: "TZ"
-              value: "{{ default 'UTC' .Values.time_zone }}"
+              value: {{ .Values.time_zone | default "UTC" | quote }}
 {{- if (.Values.deploy_hook_urls) }}
             - name: DEIS_DEPLOY_HOOK_URLS
               value: "{{ .Values.deploy_hook_urls }}"


### PR DESCRIPTION
Changes in #1196 created problems for me when deploying master charts:
```shell
$ helm install --namespace deis ./charts/controller/
Error: parse error in "controller/templates/controller-deployment.yaml": template:
controller/templates/controller-deployment.yaml:79: malformed character constant: 'UTC'
```

This fixes that error by following `default` template usage [guidelines for pipelining](https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/functions_and_pipelines.md#using-the-default-function). Works fine after this change.

```shell
$ helm install --namespace deis ./charts/controller/ 
NAME:   ringed-chicken
LAST DEPLOYED: Sun Jan 15 11:19:37 2017
NAMESPACE: deis
STATUS: DEPLOYED
...
$ helm upgrade ringed-chicken ./charts/controller/ --set controller.time_zone="America/Denver"
```
