### PR TITLE
fix(Dockerfile): force gunzip of copyright archive

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps='gcc git libffi-dev libpq-dev libldap2-dev libsasl2-dev python3-de
     apt-get clean -y && \
     # package up license files if any by appending to existing tar
     COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
-    gunzip $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    gunzip -f $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
     rm -rf \
         /usr/share/doc \
         /usr/share/man \


### PR DESCRIPTION
I'm unable to build the controller container from master due to a `gunzip` error:
```shell
Processing triggers for libc-bin (2.23-0ubuntu5) ...
Reading package lists...
Building dependency tree...
Reading state information...
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
gzip: /usr/share/copyrights.tar.gz has 19 other links -- unchanged
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
gzip: /usr/share/copyrights.tar.gz already exists;	not overwritten
```

This is probably related to switching from `ubuntu-slim` to `ubuntu` in deis/docker-base#22 somehow--see also #1197. Adding a `-f` flag seems to fix it for me.