### PR TITLE
chore(requirements): update requests to 2.13.0

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -18,5 +18,5 @@ psycopg2==2.6.2
 pyldap==2.4.28
 pyOpenSSL==16.2.0
 pytz==2016.10
-requests==2.12.5
+requests==2.13.0
 requests-toolbelt==0.7.0


### PR DESCRIPTION
From the requests library release notes:

Features
- Only load the idna library when we've determined we need it. This will save some memory for users.

Miscellaneous
- Updated bundled urllib3 to 1.20.
- Updated bundled idna to 2.2.