### PR TITLE
fix(charts): reference registry-proxy on 127.0.0.1

### DIFF
--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: {{ .Values.registration_mode }}
             # NOTE(bacongobbler): use deis/registry_proxy to work around Docker --insecure-registry requirements
             - name: "DEIS_REGISTRY_SERVICE_HOST"
-              value: "localhost"
+              value: "127.0.0.1"
             - name: "K8S_API_VERIFY_TLS"
               value: "{{ .Values.k8s_api_verify_tls }}"
             - name: "DEIS_REGISTRY_SERVICE_PORT"


### PR DESCRIPTION
On some providers, "localhost" is not set up on the host network. explicitly calling the loopback
address fixes this.

See https://github.com/deis/workflow/issues/678