### PR TITLE
chore(requirements): update ldap, drf, and requests-toolbelt

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -4,7 +4,7 @@ Django==1.10.5
 django-auth-ldap==1.2.9
 django-cors-middleware==1.3.1
 django-guardian==1.4.6
-djangorestframework==3.5.3
+djangorestframework==3.5.4
 docker-py==1.10.6
 gunicorn==19.6.0
 idna==2.2

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -19,4 +19,4 @@ pyldap==2.4.28
 pyOpenSSL==16.2.0
 pytz==2016.10
 requests==2.13.0
-requests-toolbelt==0.7.0
+requests-toolbelt==0.7.1

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,7 +1,7 @@
 # Deis controller requirements
 backoff==1.4.0
 Django==1.10.5
-django-auth-ldap==1.2.8
+django-auth-ldap==1.2.9
 django-cors-middleware==1.3.1
 django-guardian==1.4.6
 djangorestframework==3.5.3


### PR DESCRIPTION
See http://pythonhosted.org/django-auth-ldap/changes.html#v1-2-9-2017-02-14-fix-python-ldap-incompatibility
and http://www.django-rest-framework.org/topics/release-notes/#354
and https://github.com/sigmavirus24/requests-toolbelt/blob/master/HISTORY.rst#071----2017-02-13
