### PR TITLE
fix(app.py): use current namespace instead of "deis"

### DIFF
--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -125,6 +125,10 @@ spec:
                   key: password
             - name: RESERVED_NAMES
               value: "deis, deis-builder, deis-workflow-manager, grafana"
+            - name: WORKFLOW_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -992,7 +992,8 @@ class App(UuidAuditedModel):
             username = registry.get('username')
             password = registry.get('password')
         elif settings.REGISTRY_LOCATION == 'off-cluster':
-            secret = self._scheduler.secret.get('deis', 'registry-secret').json()
+            secret = self._scheduler.secret.get(
+                settings.WORKFLOW_NAMESPACE, 'registry-secret').json()
             username = secret['data']['username']
             password = secret['data']['password']
             hostname = secret['data']['hostname']
@@ -1105,5 +1106,6 @@ class App(UuidAuditedModel):
         try:
             self._scheduler.secret.get(self.id, 'objectstorage-keyfile')
         except KubeException:
-            secret = self._scheduler.secret.get('deis', 'objectstorage-keyfile').json()
+            secret = self._scheduler.secret.get(
+                settings.WORKFLOW_NAMESPACE, 'objectstorage-keyfile').json()
             self._scheduler.secret.create(self.id, 'objectstorage-keyfile', secret['data'])

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -241,6 +241,9 @@ TEMPDIR = tempfile.mkdtemp(prefix='deis')
 # names which apps cannot reserve for routing
 DEIS_RESERVED_NAMES = os.environ.get('RESERVED_NAMES', '').replace(' ', '').split(',')
 
+# the k8s namespace in which the controller and workflow were installed.
+WORKFLOW_NAMESPACE = os.environ.get('WORKFLOW_NAMESPACE', 'deis')
+
 # default scheduler settings
 SCHEDULER_MODULE = 'scheduler'
 SCHEDULER_URL = "https://{}:{}".format(


### PR DESCRIPTION
Uses the k8s downward api to make the current namespace available to controller so it isn't hard-coded as "deis."

Closes #1246.
Closes deis/charts#18.
Closes deis/builder#483.