### PR TITLE
ref(utils): use python 3.5 asyncio keywords

### DIFF
--- a/rootfs/api/utils.py
+++ b/rootfs/api/utils.py
@@ -171,15 +171,14 @@ def async_run(tasks):
     executor.shutdown(wait=True)
 
 
-@asyncio.coroutine
-def async_task(params, loop):
+async def async_task(params, loop):
     """
-    performs an async task
+    Perform a task asynchronously.
     """
     # get the calling function
     logger.debug('Running {}'.format(params))
     # This executes a task in its own thread (in parallel)
-    yield from loop.run_in_executor(None, params)
+    await loop.run_in_executor(None, params)
     logger.debug('Finished running {}'.format(params))
 
 


### PR DESCRIPTION
The decorator syntax for `asyncio` in python 3.4 was considered provisional and is superseded in python 3.5 by new keywords such as `async` and `await`. Controller already requires Python 3.5. This change makes some code a bit more readable and future-proofed.