### PR TITLE
chore(requirements): update psycopg2 to 2.7.1

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -15,7 +15,7 @@ morph==0.1.2
 ndg-httpsclient==0.4.2
 packaging==16.8
 pyasn1==0.2.3
-psycopg2==2.7
+psycopg2==2.7.1
 pyldap==2.4.28
 pyOpenSSL==16.2.0
 pytz==2016.10


### PR DESCRIPTION
See http://pythonhosted.org/psycopg2/news.html#what-s-new-in-psycopg-2-7-1