### PR TITLE
feat(Makefile,rootfs): run unit and style tests in container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _tests/example-*/
 # coverage reports
 .coverage
 coverage.out
+coverage.xml
 htmlcov/
 
 # python virtual environments for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,12 @@ branches:
   only:
     - master
 services:
-  - postgresql
   - docker
 env:
   - DOCKER_BUILD_FLAGS="--pull --no-cache"
 sudo: required
-addons:
-  postgresql: "9.4"
 cache: pip
-before_install:
-  - createdb -U postgres deis
-install:
-  - pip install -r rootfs/requirements.txt
-  - pip install -r rootfs/dev_requirements.txt
 script:
   - make test
 after_success:
-  - pushd rootfs/ && codecov && popd
+  - make upload-coverage

--- a/rootfs/.coveragerc
+++ b/rootfs/.coveragerc
@@ -25,4 +25,4 @@ exclude_lines =
     if __name__ == .__main__.:
 
 [html]
-title = Deis Coverage Report
+title = Controller Coverage Report

--- a/rootfs/Dockerfile.test
+++ b/rootfs/Dockerfile.test
@@ -8,6 +8,7 @@ RUN adduser --system \
 	deis
 
 COPY requirements.txt /app/requirements.txt
+COPY dev_requirements.txt /app/dev_requirements.txt
 
 RUN buildDeps='gcc libffi-dev libpq-dev libldap2-dev libsasl2-dev python3-dev python3-pip python3-wheel python3-setuptools'; \
     apt-get update && \
@@ -44,9 +45,20 @@ RUN buildDeps='gcc libffi-dev libpq-dev libldap2-dev libsasl2-dev python3-dev py
         /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
     bash -c "mkdir -p /usr/share/man/man{1..8}"
 
-COPY . /app
-
 # define execution environment
 WORKDIR /app
-CMD ["/app/bin/boot"]
-EXPOSE 8000
+
+# test-unit additions to the main Dockerfile
+ENV PGBIN=/usr/lib/postgresql/9.5/bin PGDATA=/var/lib/postgresql/data
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git \
+        postgresql \
+        postgresql-contrib \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel && \
+    pip3 install --disable-pip-version-check --no-cache-dir -r dev_requirements.txt && \
+    sudo -u postgres -E $PGBIN/initdb
+
+CMD ["/app/bin/test-unit"]

--- a/rootfs/api/settings/testing.py
+++ b/rootfs/api/settings/testing.py
@@ -25,6 +25,7 @@ ROUTER_PORT = 80
 # randomize test database name so we can run multiple unit tests simultaneously
 DATABASES['default']['NAME'] = "unittest-{}".format(''.join(
     random.choice(string.ascii_letters + string.digits) for _ in range(8)))
+DATABASES['default']['USER'] = 'postgres'
 
 # use DB name to isolate the data for each test run
 CACHES = {

--- a/rootfs/bin/test-style
+++ b/rootfs/bin/test-style
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# This script is designed to be run inside the container
+#
+
+# fail hard and fast even on pipelines
+set -eou pipefail
+
+flake8 --show-source

--- a/rootfs/bin/test-unit
+++ b/rootfs/bin/test-unit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# This script is designed to be run inside the container
+#
+
+# fail hard and fast even on pipelines
+set -eou pipefail
+
+sudo -u postgres "$PGBIN"/pg_ctl -D "$PGDATA" -l /tmp/logfile start
+python3 manage.py check
+coverage run manage.py test --settings=api.settings.testing --noinput registry api scheduler.tests
+coverage report -m

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -9,7 +9,7 @@ codecov==2.0.5
 
 # mock out python-requests, mostly k8s
 # requests-mock==1.0.0
--e git+https://github.com/helgi/requests-mock.git@class_adapter#egg=request_mock
+git+https://github.com/helgi/requests-mock.git@class_adapter#egg=request_mock
 
 # tail a log and pipe into tbgrep to find all tracebacks
 tbgrep==0.3.0

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -8,8 +8,8 @@ flake8==3.3.0
 codecov==2.0.5
 
 # mock out python-requests, mostly k8s
-# requests-mock==1.0.0
-git+https://github.com/helgi/requests-mock.git@class_adapter#egg=request_mock
+# requests-mock==1.3.0
+git+https://github.com/deis/requests-mock.git@class_adapter#egg=request_mock
 
 # tail a log and pipe into tbgrep to find all tracebacks
 tbgrep==0.3.0


### PR DESCRIPTION
Coerces `make test-style` and `make test-unit` to run in containers, which avoids the need to have Python 3.5 and the packages in `dev_requirements.txt` on your local workstation. Also updates the fork of requests-mock to that in the deis org.

Closes #18.
Closes #1049.

See also deis/docker-python-dev#11 and deis/dockerbuilder#120. If that approach is acceptable, this could be refactored similarly for `make test-style` at least.