### PR TITLE
chore(Makefile): remove broken "test-unit-quick" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,6 @@ test-unit:
 		&& coverage run manage.py test --settings=api.settings.testing --noinput registry api scheduler.tests \
 		&& coverage report -m
 
-test-unit-quick:
-	cd rootfs \
-		&& ./manage.py test --settings=api.settings.testing --noinput --parallel ${TEST_PROCS} registry api scheduler.tests
-
 test-functional:
 	@echo "Implement functional tests in _tests directory"
 

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -1,18 +1,15 @@
-# Run "make coverage" or "make test-unit" for the % of code exercised during tests
+# Run "make test-unit" for the % of code exercised during tests
 coverage==4.3.4
 
-# Run "make flake8" to check python syntax and style
+# Run "make test-style" to check python syntax and style
 flake8==3.3.0
 
-# code coverage report at https://codecov.io/github/deis/workflow
+# code coverage report at https://codecov.io/github/deis/controller
 codecov==2.0.5
 
 # mock out python-requests, mostly k8s
 # requests-mock==1.0.0
 -e git+https://github.com/helgi/requests-mock.git@class_adapter#egg=request_mock
-
-# tblib is needed to pickle tracebacks for `make test-unit-quick`
-tblib==1.3.0
 
 # tail a log and pipe into tbgrep to find all tracebacks
 tbgrep==0.3.0


### PR DESCRIPTION
I added `make test-unit-quick` long ago as a developer convenience when I saw that Django's test framework had a `--parallel` flag. But this target seems to have rusted over time; I get multiple failures on every run--errors that don't appear with `make test-unit`.

This target isn't referenced in CI (and I never really used it), so let's simplify life by removing it and the `tblib` package it needed.

Closes #1273.