### PR TITLE
chore(requirements): update backoff library to v1.4.2

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,5 +1,5 @@
 # Deis controller requirements
-backoff==1.4.0
+backoff==1.4.2
 Django==1.11
 django-auth-ldap==1.2.10
 django-cors-middleware==1.3.1


### PR DESCRIPTION
See https://github.com/litl/backoff/releases/tag/v1.4.2