### PR TITLE
RBAC support

### DIFF
--- a/charts/controller/templates/_helpers.tmpl
+++ b/charts/controller/templates/_helpers.tmpl
@@ -1,0 +1,10 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/controller/templates/controller-clusterrole.yaml
+++ b/charts/controller/templates/controller-clusterrole.yaml
@@ -1,0 +1,59 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRole
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-controller
+  labels:
+    app: deis-controller
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "create", "update", "delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "get", "create", "update", "delete"]
+- apiGroups: [""]
+  resources: ["replicationcontrollers"]
+  verbs: ["get", "list", "create", "update", "delete"]
+- apiGroups: [""]
+  resources: ["replicationcontrollers/scale"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "delete"]
+- apiGroups: [""]
+  resources: ["resourcequotas"]
+  verbs: ["get", "create"]
+- apiGroups: ["extensions"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "delete", "update"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "create", "update", "delete"]
+- apiGroups: ["extensions"]
+  resources: ["deployments/scale", "replicasets/scale"]
+  verbs: ["get", "update"]
+- apiGroups: ["extensions", "autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "create", "update", "delete"]
+{{ if .Values.global.experimental_native_ingress }}
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/controller/templates/controller-clusterrolebinding.yaml
+++ b/charts/controller/templates/controller-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-controller
+  labels:
+    app: deis-controller
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deis:deis-controller
+subjects:
+- kind: ServiceAccount
+  name: deis-controller
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -55,3 +55,5 @@ global:
   # - true: The deis controller will now create Kubernetes ingress rules for each app, and ingress rules will automatically be created for the controller itself.
   # - false: The default mode, and the default behavior of Deis workflow.
   experimental_native_ingress: false
+  # Role-Based Access Control for Kubernetes >= 1.5
+  use_rbac: false


### PR DESCRIPTION
With this change deis-controller became available to work in RBAC-only clusters

Works with both Kubernetes 1.5 and 1.6 (see templates/_helpers.tmpl for details)
Actually tested with 1.5.7 and 1.6.4

ClusterRole allows deis-controller:
- namespaces: `get`, `list`, `create` and delete
- services: `get`, `list`, `create`, `update` and `delete`
- nodes: `get` and `list`
- events: `list` and `create`
- secrets: `list`, `get`, `create`, `update` and `delete`
- replicationcontrollers: `get`, `list`, `create`, `update` and `delete`
- replicationcontrollers/scale: `get` and `update`
- pods/log: `get`
- pods: `get`, `list` and `delete`
- resourcequotas: `get` and `create`
- apps/deployments: `get`, `list`, `create`, `update` and `delete`
- autoscaling/horizontalpodautoscalers: `get`, `list`, `create`, `update` and `delete`
- extensions/deployments: `get`, `list`, `create`, `update` and `delete`
- extensions/deployments/scale: `get` and `update`
- extensions/replicasets: `get`, `list`, `delete` and `update`
- extensions/replicasets/scale: `get` and `update`
- extensions/horizontalpodautoscalers: `get`, `list`, `create`, `update` and `delete`
- extensions/ingresses: `get`, `list`, `watch`, `create`, `update` and `delete`