### PR TITLE
chore(requirements): update pyldap to v2.4.35

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -16,7 +16,7 @@ ndg-httpsclient==0.4.2
 packaging==16.8
 pyasn1==0.2.3
 psycopg2==2.7.1
-pyldap==2.4.28
+pyldap==2.4.35
 pyOpenSSL==17.0.0
 pytz==2017.2
 requests==2.13.0


### PR DESCRIPTION
From the CHANGES doc at https://github.com/pyldap/pyldap/blob/master/CHANGES:


----------------------------------------------------------------
Released 2.4.35 2017-04-25 (upstream)

Changes since 2.4.33:
(2.4.34 is missing because of foolish pypi version madness)

Modules/
* use errno in a safer way
* set errno as LDAPError class item
* do not use strerror() which is not thread-safe and platform-specific

Lib/
* LDAPObject._ldap_call() sets LDAPError info to value returned
  by platform-neutral os.stderror()

----------------------------------------------------------------
Released 2.4.33 2017-04-25 (upstream)

Lib/
* faster implementation of ldap.schema.tokenizer.split_tokens()
  (thanks to Christian Heimes)
* removed unused 2nd argument of ldap.schema.tokenizer.split_tokens()
* fixed method calls in ReconnectLDAPObject (thanks to Philipp Hahn)

Modules/
* an empty info message is replaced with strerror(errno) if errno is non-zero
  which gives more information e.g. in case of ldap.SERVER_DOWN
  (thanks to Markus Klein)
* removed superfluous ldap_memfree(error) from LDAPerror()
  (thanks to Markus Klein)

Tests/
* re-factored t_ldap_schema_tokenizer.py

----------------------------------------------------------------
Released 2.4.32 2017-02-14 (upstream)

Running tests made easier:
- python setup.py test
- added tox.ini

----------------------------------------------------------------
Released 2.4.31 2017-02-14 (upstream)

Changes since 2.4.30:

Tests/
* new test scripts t_ldap_schema_tokenizer.py and t_ldap_modlist.py
  on former raw scripts (thanks to Petr Viktorin)
* new test-cases in t_ldapurl.py based on former raw scripts
  (thanks to Petr Viktorin)
* new test-cases in t_ldap_dn.py
* moved a script to Demo/

----------------------------------------------------------------
Released 2.4.30 2017-02-08 (upstream)

Changes since 2.4.29:

Lib/
* compability fix in ldap.controls.deref to be compatible to
  recent pyasn1 0.2.x (thanks to Ilya Etingof)

----------------------------------------------------------------
Released 2.4.29 2017-01-25 (upstream)

Changes since 2.4.28:

Modules/
* Fixed checking for empty server error message
  (thanks to Bradley Baetz)
* Fixed releasing GIL when calling ldap_start_tls_s()
  (thanks to Lars Munch)
