### PR TITLE
Adding a working install-k8s link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 
-[install-k8s]: http://kubernetes.io/gettingstarted/
+[install-k8s]: https://kubernetes.io/docs/setup/pick-right-solution
 [issues]: https://github.com/deis/controller/issues
 [prs]: https://github.com/deis/controller/pulls
 [workflow]: https://github.com/deis/workflow


### PR DESCRIPTION
Adding a new link for getting started with k8s so developers can test by install with minikube or another platform.
